### PR TITLE
Do not commit read-only transactions

### DIFF
--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -61,6 +61,7 @@ typedef struct _ErlFDBTransaction
     unsigned int txid;
     bool read_only;
     bool writes_allowed;
+    bool has_watches;
 } ErlFDBTransaction;
 
 

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -109,6 +109,7 @@
     % Transaction status
     get_next_tx_id/1,
     is_read_only/1,
+    has_watches/1,
     get_writes_allowed/1,
 
     % Locality
@@ -592,6 +593,13 @@ is_read_only(?IS_TX = Tx) ->
 
 is_read_only(?IS_SS = SS) ->
     is_read_only(?GET_TX(SS)).
+
+
+has_watches(?IS_TX = Tx) ->
+    erlfdb_nif:transaction_has_watches(Tx);
+
+has_watches(?IS_SS = SS) ->
+    has_watches(?GET_TX(SS)).
 
 
 get_writes_allowed(?IS_TX = Tx) ->

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -653,7 +653,10 @@ clear_erlfdb_error() ->
 do_transaction(?IS_TX = Tx, UserFun) ->
     try
         Ret = UserFun(Tx),
-        wait(commit(Tx)),
+        case is_read_only(Tx) andalso not has_watches(Tx) of
+            true -> ok;
+            false -> wait(commit(Tx))
+        end,
         Ret
     catch error:{erlfdb_error, Code} ->
         put(?ERLFDB_ERROR, Code),

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -52,6 +52,7 @@
     transaction_add_conflict_range/4,
     transaction_get_next_tx_id/1,
     transaction_is_read_only/1,
+    transaction_has_watches/1,
     transaction_get_writes_allowed/1,
     transaction_get_approximate_size/1,
 
@@ -430,6 +431,11 @@ transaction_is_read_only({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_is_read_only(Tx).
 
 
+-spec transaction_has_watches(transaction()) -> true | false.
+transaction_has_watches({erlfdb_transaction, Tx}) ->
+    erlfdb_transaction_has_watches(Tx).
+
+
 -spec transaction_get_writes_allowed(transaction()) -> true | false.
 transaction_get_writes_allowed({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_writes_allowed(Tx).
@@ -575,6 +581,7 @@ erlfdb_transaction_add_conflict_range(
     ) -> ?NOT_LOADED.
 erlfdb_transaction_get_next_tx_id(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_is_read_only(_Transaction) -> ?NOT_LOADED.
+erlfdb_transaction_has_watches(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_writes_allowed(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_approximate_size(_Transaction) -> ?NOT_LOADED.
 

--- a/test/erlfdb_03_transaction_options_test.erl
+++ b/test/erlfdb_03_transaction_options_test.erl
@@ -59,5 +59,28 @@ once_writes_happend_cannot_disallow_them_test() ->
     end)).
 
 
+has_watches_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    {Before, After, AfterReset} = (erlfdb:transactional(Db1, fun(Tx) ->
+        Before = erlfdb:has_watches(Tx),
+        erlfdb:watch(Tx, gen(10)),
+        After = erlfdb:has_watches(Tx),
+        erlfdb:reset(Tx),
+        AfterReset = erlfdb:has_watches(Tx),
+        {Before, After, AfterReset}
+    end)),
+    ?assert(not Before),
+    ?assert(After),
+    ?assert(not AfterReset).
+
+
+cannot_set_watches_if_writes_disallowed_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    ?assertError(writes_not_allowed, erlfdb:transactional(Db1, fun(Tx) ->
+        erlfdb:set_option(Tx, disallow_writes),
+        erlfdb:watch(Tx, gen(10))
+    end)).
+
+
 gen(Size) ->
     crypto:strong_rand_bytes(Size).


### PR DESCRIPTION
This might save a round-trip to the [network thread]( https://forums.foundationdb.org/t/performance-of-read-only-transactions/1998). It also follows the [recommendation](https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_commit) in the C api docs.

However, it turns out in order for the watches to fire a read-only transaction still has to commit. To fix that added a transaction flag to check for watches and avoid this optimization if it returns true.