### PR TITLE
Add more database options

### DIFF
--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -78,6 +78,7 @@ ATOM_MAP(causal_write_risky);
 ATOM_MAP(causal_read_risky);
 ATOM_MAP(causal_read_disable);
 ATOM_MAP(next_write_no_write_conflict_range);
+ATOM_MAP(read_your_writes_enable);
 ATOM_MAP(read_your_writes_disable);
 ATOM_MAP(read_ahead_disable);
 ATOM_MAP(durability_datacenter);
@@ -90,6 +91,9 @@ ATOM_MAP(access_system_keys);
 ATOM_MAP(read_system_keys);
 ATOM_MAP(debug_retry_logging);
 ATOM_MAP(transaction_logging_enable);
+ATOM_MAP(debug_transaction_identifier);
+ATOM_MAP(transaction_logging_max_field_length);
+ATOM_MAP(log_transaction);
 ATOM_MAP(timeout);
 ATOM_MAP(retry_limit);
 ATOM_MAP(max_retry_delay);
@@ -101,6 +105,8 @@ ATOM_MAP(read_lock_aware);
 ATOM_MAP(size_limit);
 ATOM_MAP(allow_writes);
 ATOM_MAP(disallow_writes);
+ATOM_MAP(include_port_in_address);
+ATOM_MAP(use_provisional_proxies);
 
 
 // Streaming mode

--- a/c_src/main.c
+++ b/c_src/main.c
@@ -752,7 +752,24 @@ erlfdb_database_set_option(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         option = FDB_DB_OPTION_MACHINE_ID;
     } else if(IS_ATOM(argv[1], datacenter_id)) {
         option = FDB_DB_OPTION_DATACENTER_ID;
-    } else {
+    } else if(IS_ATOM(argv[1], read_your_writes_enable)) {
+        option = FDB_DB_OPTION_SNAPSHOT_RYW_ENABLE;
+    } else if(IS_ATOM(argv[1], read_your_writes_disable)) {
+        option = FDB_DB_OPTION_SNAPSHOT_RYW_DISABLE;
+    } else if(IS_ATOM(argv[1], transaction_logging_max_field_length)) {
+        option = FDB_DB_OPTION_TRANSACTION_LOGGING_MAX_FIELD_LENGTH;
+    } else if(IS_ATOM(argv[1], timeout)) {
+        option = FDB_DB_OPTION_TRANSACTION_TIMEOUT;
+    } else if(IS_ATOM(argv[1], retry_limit)) {
+        option = FDB_DB_OPTION_TRANSACTION_RETRY_LIMIT;
+    } else if(IS_ATOM(argv[1], max_retry_delay)) {
+        option = FDB_DB_OPTION_TRANSACTION_MAX_RETRY_DELAY;
+    } else if(IS_ATOM(argv[1], size_limit)) {
+        option = FDB_DB_OPTION_TRANSACTION_SIZE_LIMIT;
+    } else if(IS_ATOM(argv[1], causal_read_risky)) {
+        option = FDB_DB_OPTION_TRANSACTION_CAUSAL_READ_RISKY;
+    } else if(IS_ATOM(argv[1], include_port_in_address)) {
+        option = FDB_DB_OPTION_TRANSACTION_INCLUDE_PORT_IN_ADDRESS;
         return enif_make_badarg(env);
     }
 
@@ -875,6 +892,8 @@ erlfdb_transaction_set_option(
         option = FDB_TR_OPTION_CAUSAL_READ_RISKY;
     } else if(IS_ATOM(argv[1], causal_read_disable)) {
         option = FDB_TR_OPTION_CAUSAL_READ_DISABLE;
+    } else if(IS_ATOM(argv[1], include_port_in_address)) {
+        option = FDB_TR_OPTION_INCLUDE_PORT_IN_ADDRESS;
     } else if(IS_ATOM(argv[1], next_write_no_write_conflict_range)) {
         option = FDB_TR_OPTION_NEXT_WRITE_NO_WRITE_CONFLICT_RANGE;
     } else if(IS_ATOM(argv[1], read_your_writes_disable)) {
@@ -901,6 +920,12 @@ erlfdb_transaction_set_option(
         option = FDB_TR_OPTION_DEBUG_RETRY_LOGGING;
     } else if(IS_ATOM(argv[1], transaction_logging_enable)) {
         option = FDB_TR_OPTION_TRANSACTION_LOGGING_ENABLE;
+    } else if(IS_ATOM(argv[1], debug_transaction_identifier)) {
+        option = FDB_TR_OPTION_DEBUG_TRANSACTION_IDENTIFIER;
+    } else if(IS_ATOM(argv[1], log_transaction)) {
+        option = FDB_TR_OPTION_LOG_TRANSACTION;
+    } else if(IS_ATOM(argv[1], transaction_logging_max_field_length)) {
+        option = FDB_TR_OPTION_TRANSACTION_LOGGING_MAX_FIELD_LENGTH;
     } else if(IS_ATOM(argv[1], timeout)) {
         option = FDB_TR_OPTION_TIMEOUT;
     } else if(IS_ATOM(argv[1], retry_limit)) {
@@ -919,6 +944,8 @@ erlfdb_transaction_set_option(
         option = FDB_TR_OPTION_READ_LOCK_AWARE;
     } else if(IS_ATOM(argv[1], size_limit)) {
         option = FDB_TR_OPTION_SIZE_LIMIT;
+    } else if(IS_ATOM(argv[1], use_provisional_proxies)) {
+        option = FDB_TR_OPTION_USE_PROVISIONAL_PROXIES;
     } else {
         return enif_make_badarg(env);
     }

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -238,7 +238,8 @@ database_set_option(Database, Option) ->
         Value::option_value()
     ) -> ok.
 database_set_option({erlfdb_database, Db}, Opt, Val) ->
-    erlfdb_database_set_option(Db, Opt, Val).
+    BinVal = option_val_to_binary(Val),
+    erlfdb_database_set_option(Db, Opt, BinVal).
 
 
 -spec database_create_transaction(database()) ->
@@ -258,10 +259,7 @@ transaction_set_option(Transaction, Option) ->
         Value::option_value()
     ) -> ok.
 transaction_set_option({erlfdb_transaction, Tx}, Opt, Val) ->
-    BinVal = case Val of
-        B when is_binary(B) -> B;
-        I when is_integer(I) -> <<I:8/little-unsigned-integer-unit:8>>
-    end,
+    BinVal = option_val_to_binary(Val),
     erlfdb_transaction_set_option(Tx, Opt, BinVal).
 
 
@@ -450,6 +448,14 @@ get_error(Error) ->
         boolean().
 error_predicate(Predicate, Error) ->
     erlfdb_error_predicate(Predicate, Error).
+
+
+-spec option_val_to_binary(binary() | integer()) -> binary().
+option_val_to_binary(Val) when is_binary(Val) ->
+    Val;
+
+option_val_to_binary(Val) when is_integer(Val) ->
+    <<Val:8/little-unsigned-integer-unit:8>>.
 
 
 init() ->

--- a/test/erlfdb_03_transaction_options_test.erl
+++ b/test/erlfdb_03_transaction_options_test.erl
@@ -90,5 +90,6 @@ size_limit_on_db_handle_test() ->
     end)).
 
 
-gen(Size) ->
-    crypto:strong_rand_bytes(Size).
+gen(Size) when is_integer(Size), Size > 1 ->
+    RandBin = crypto:strong_rand_bytes(Size - 1),
+    <<0, RandBin/binary>>.

--- a/test/erlfdb_03_transaction_options_test.erl
+++ b/test/erlfdb_03_transaction_options_test.erl
@@ -82,5 +82,13 @@ cannot_set_watches_if_writes_disallowed_test() ->
     end)).
 
 
+size_limit_on_db_handle_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    erlfdb:set_option(Db1, size_limit, 10000),
+    ?assertError({erlfdb_error, 2101}, erlfdb:transactional(Db1, fun(Tx) ->
+         erlfdb:set(Tx, gen(10), gen(11000))
+    end)).
+
+
 gen(Size) ->
     crypto:strong_rand_bytes(Size).


### PR DESCRIPTION
Since FDB version 6.1 [1] it is possible to set default transaction
options on database handles, and any transactions created from that
handle will inherit those options.

[1] https://apple.github.io/foundationdb/old-release-notes/release-notes-610.html

When running the eunit test noticed we could be generating test keys
in the system range so added a commit to fix that as well.