### PR TITLE
code:priv_dir/1 expects application name

### DIFF
--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -197,7 +197,7 @@ write_cluster_file(FileName, ClusterName, ClusterId, IpAddr, Port) ->
 
 
 get_monitor_path() ->
-    PrivDir = case code:priv_dir(?MODULE) of
+    PrivDir = case code:priv_dir(erlfdb) of
         {error, _} ->
             EbinDir = filename:dirname(code:which(?MODULE)),
             AppPath = filename:dirname(EbinDir),


### PR DESCRIPTION
This PR fixes errors like the following 
```
Cannot start application 'fabric', reason {{shutdown,
                                            {failed_to_start_child,
                                             fabric2_server,
                                             {{fdbserver_error,
                                               {'DOWN',
                                                #Ref<0.1410357759.267386884.187034>,
                                                process,<0.2051.0>,
                                                {enoent,
                                                 [{erlang,open_port,
                                                   [{spawn_executable,
                                                     "./priv/monitor.py"},
```

To test the failure following was used:
```
❯ ERL_LIBS=(pwd)/.. erl
Erlang/OTP 22 [erts-10.5.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe] [dtrace]

Eshell V10.5.5  (abort with ^G)
1> code:priv_dir(erlfdb_util).
{error,bad_name}
2> code:priv_dir(erlfdb).
"/Users/iilyak/dev/fdb-dbcore/src/couchdb/../erlfdb/priv"
```