### PR TITLE
(feat) Add native encoding decoding for atoms/lists/maps to erlfdb_tuple

### DIFF
--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -68,8 +68,6 @@
 % Floats and Doubles
 -define(FLOAT, 16#20).
 -define(DOUBLE, 16#21).
--define(FLOAT_ZERO,  <<?FLOAT,  128, 0, 0, 0, 0, 0, 0, 0>>). %% 0.0
--define(DOUBLE_ZERO, <<?DOUBLE, 128, 0, 0, 0, 0, 0, 0, 0>>). %% 0.0
 
 % Booleans are a single byte each
 -define(FALSE, 16#26).
@@ -370,14 +368,16 @@ decode(<<?POS_INT_8, Rest/binary>>, Depth) -> dec_pos_int(Rest, 8, Depth);
 decode(<<?POS_INT_9P, Size:8/unsigned-integer, Rest/binary>>, Depth) ->
     dec_pos_int(Rest, Size, Depth);
 
-decode(?FLOAT_ZERO, _Depth) ->
-    {[0.0], <<>>};
+decode(<<?FLOAT, 128, 0, 0, 0, 0, 0, 0, 0, Rest/binary>>, Depth) ->
+    {Values, Tail} = decode(Rest, Depth),
+    {[0.0 | Values], Tail};
 decode(<<?FLOAT, Raw:4/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};
 
-decode(?DOUBLE_ZERO, _Depth) ->
-    {[0.0], <<>>};
+decode(<<?DOUBLE, 128, 0, 0, 0, 0, 0, 0, 0, Rest/binary>>, Depth) ->
+    {Values, Tail} = decode(Rest, Depth),
+    {[0.0 | Values], Tail};
 decode(<<?DOUBLE, Raw:8/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};

--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -67,7 +67,9 @@
 
 % Floats and Doubles
 -define(FLOAT, 16#20).
+-define(FLOAT_ZERO, <<?FLOAT, 128, 0, 0, 0, 0, 0, 0, 0, 0>>).
 -define(DOUBLE, 16#21).
+-define(DOUBLE_ZERO, <<?DOUBLE, 128, 0, 0, 0, 0, 0, 0, 0, 0>>).
 
 % Booleans are a single byte each
 -define(FALSE, 16#26).
@@ -368,13 +370,13 @@ decode(<<?POS_INT_8, Rest/binary>>, Depth) -> dec_pos_int(Rest, 8, Depth);
 decode(<<?POS_INT_9P, Size:8/unsigned-integer, Rest/binary>>, Depth) ->
     dec_pos_int(Rest, Size, Depth);
 
-decode(<<?FLOAT, 0,0,0,0,0,0,0,0>>, _Depth) ->
+decode(<<?FLOAT_ZERO>>, _Depth) ->
     0.0;
 decode(<<?FLOAT, Raw:4/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};
 
-decode(<<?DOUBLE, 0,0,0,0,0,0,0,0>>, _Depth) ->
+decode(<<?DOUBLE_ZERO>>, _Depth) ->
     0.0;
 decode(<<?DOUBLE, Raw:8/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),

--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -370,13 +370,13 @@ decode(<<?POS_INT_8, Rest/binary>>, Depth) -> dec_pos_int(Rest, 8, Depth);
 decode(<<?POS_INT_9P, Size:8/unsigned-integer, Rest/binary>>, Depth) ->
     dec_pos_int(Rest, Size, Depth);
 
-decode(<<?FLOAT_ZERO>>, _Depth) ->
+decode(?FLOAT_ZERO, _Depth) ->
     0.0;
 decode(<<?FLOAT, Raw:4/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};
 
-decode(<<?DOUBLE_ZERO>>, _Depth) ->
+decode(?DOUBLE_ZERO, _Depth) ->
     0.0;
 decode(<<?DOUBLE, Raw:8/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),

--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -67,9 +67,9 @@
 
 % Floats and Doubles
 -define(FLOAT, 16#20).
--define(FLOAT_ZERO, <<?FLOAT, 128, 0, 0, 0, 0, 0, 0, 0, 0>>).
 -define(DOUBLE, 16#21).
--define(DOUBLE_ZERO, <<?DOUBLE, 128, 0, 0, 0, 0, 0, 0, 0, 0>>).
+-define(FLOAT_ZERO,  <<?FLOAT,  128, 0, 0, 0, 0, 0, 0, 0>>). %% 0.0
+-define(DOUBLE_ZERO, <<?DOUBLE, 128, 0, 0, 0, 0, 0, 0, 0>>). %% 0.0
 
 % Booleans are a single byte each
 -define(FALSE, 16#26).
@@ -371,13 +371,13 @@ decode(<<?POS_INT_9P, Size:8/unsigned-integer, Rest/binary>>, Depth) ->
     dec_pos_int(Rest, Size, Depth);
 
 decode(?FLOAT_ZERO, _Depth) ->
-    0.0;
+    {[0.0], <<>>};
 decode(<<?FLOAT, Raw:4/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};
 
 decode(?DOUBLE_ZERO, _Depth) ->
-    0.0;
+    {[0.0], <<>>};
 decode(<<?DOUBLE, Raw:8/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};

--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -371,11 +371,19 @@ decode(<<?POS_INT_9P, Size:8/unsigned-integer, Rest/binary>>, Depth) ->
 decode(<<?FLOAT, 128, 0, 0, 0, 0, 0, 0, 0, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[0.0 | Values], Tail};
+decode(<<?FLOAT, 128, 0, 0, 0, Rest/binary>>, Depth) ->
+    %% encoded from tagged value
+    {Values, Tail} = decode(Rest, Depth),
+    {[0.0 | Values], Tail};
 decode(<<?FLOAT, Raw:4/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};
 
 decode(<<?DOUBLE, 128, 0, 0, 0, 0, 0, 0, 0, Rest/binary>>, Depth) ->
+    {Values, Tail} = decode(Rest, Depth),
+    {[0.0 | Values], Tail};
+decode(<<?DOUBLE, 128, 0, 0, 0, Rest/binary>>, Depth) ->
+    %% encoded from tagged value
     {Values, Tail} = decode(Rest, Depth),
     {[0.0 | Values], Tail};
 decode(<<?DOUBLE, Raw:8/binary, Rest/binary>>, Depth) ->

--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -368,10 +368,14 @@ decode(<<?POS_INT_8, Rest/binary>>, Depth) -> dec_pos_int(Rest, 8, Depth);
 decode(<<?POS_INT_9P, Size:8/unsigned-integer, Rest/binary>>, Depth) ->
     dec_pos_int(Rest, Size, Depth);
 
+decode(<<?FLOAT, 0,0,0,0,0,0,0,0>>, _Depth) ->
+    0.0;
 decode(<<?FLOAT, Raw:4/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};
 
+decode(<<?DOUBLE, 0,0,0,0,0,0,0,0>>, _Depth) ->
+    0.0;
 decode(<<?DOUBLE, Raw:8/binary, Rest/binary>>, Depth) ->
     {Values, Tail} = decode(Rest, Depth),
     {[dec_float(Raw) | Values], Tail};

--- a/test/erlfdb_01_basic_test.erl
+++ b/test/erlfdb_01_basic_test.erl
@@ -16,6 +16,7 @@
 
 
 load_test() ->
+    erlfdb_nif:init(),
     erlfdb_nif:ohai().
 
 

--- a/test/erlfdb_02_anon_fdbserver_test.erl
+++ b/test/erlfdb_02_anon_fdbserver_test.erl
@@ -16,6 +16,7 @@
 
 
 basic_init_test() ->
+    erlfdb_nif:init(),
     {ok, ClusterFile} = erlfdb_util:init_test_cluster([]),
     ?assert(is_binary(ClusterFile)).
 

--- a/test/erlfdb_03_transaction_options_test.erl
+++ b/test/erlfdb_03_transaction_options_test.erl
@@ -16,6 +16,7 @@
 
 
 get_approximate_tx_size_test() ->
+    erlfdb_nif:init(),
     Db1 = erlfdb_util:get_test_db(),
     erlfdb:transactional(Db1, fun(Tx) ->
          ok = erlfdb:set(Tx, gen(10), gen(5000)),

--- a/test/erlfdb_05_get_next_tx_id_test.erl
+++ b/test/erlfdb_05_get_next_tx_id_test.erl
@@ -16,6 +16,7 @@
 
 
 get_tx_id_test() ->
+    erlfdb_nif:init(),
     Db = erlfdb_util:get_test_db(),
     erlfdb:transactional(Db, fun(Tx) ->
         lists:foreach(fun(I) ->

--- a/test/tester.es
+++ b/test/tester.es
@@ -1011,7 +1011,7 @@ main([Prefix, APIVsn, ClusterFileStr]) ->
     %% Prompt = io_lib:format("GDB Attach to: ~s~n", [os:getpid()]),
     %% io:get_line(Prompt),
     %% io:format("Running tests: ~s ~s ~s~n", [Prefix, APIVsn, ClusterFileStr]),
-
+    erlfdb_nif:init(),
     application:set_env(erlfdb, api_version, list_to_integer(APIVsn)),
     Db = erlfdb:open(iolist_to_binary(ClusterFileStr)),
     init_run_loop(Db, iolist_to_binary(Prefix)).


### PR DESCRIPTION
Not having support for atoms/lists and maps in erlfdb makes the tuple layer more complex to use.

This PR adds support for transparent encoding/decoding from/to native erlang `atom`, `list` and `map` types.

My specific use case is for storing erlang records in fdb and have the native records as results when selected.

I'd prefer not to hammer term_to_binary and binary_to_term for every single operation in my app.

I used the documented "User type codes" (Typecodes: 0x40 - 0x4f) to specify these.

Honestly not sure if this should be included here.

Maybe there is a better way to design this? 
