### PR TITLE
Do not apply default future timeouts to commit and on_error response

### DIFF
--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -663,12 +663,12 @@ do_transaction(?IS_TX = Tx, UserFun) ->
         Ret = UserFun(Tx),
         case is_read_only(Tx) andalso not has_watches(Tx) of
             true -> ok;
-            false -> wait(commit(Tx))
+            false -> wait(commit(Tx), [{timeout, infinity}])
         end,
         Ret
     catch error:{erlfdb_error, Code} ->
         put(?ERLFDB_ERROR, Code),
-        wait(on_error(Tx, Code)),
+        wait(on_error(Tx, Code), [{timeout, infinity}]),
         do_transaction(Tx, UserFun)
     end.
 


### PR DESCRIPTION
`commit` should timeout based on the default transaction_too_old (1007) error
or from an explicitly set transaction timeout option (1031).

`on_error` may sleep for some time which is determined by the backoff and retry
counts,it is limited and is guaranteed to return back.