### PR TITLE
Add support for reporting conflicting keys

### DIFF
--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -107,6 +107,7 @@ ATOM_MAP(allow_writes);
 ATOM_MAP(disallow_writes);
 ATOM_MAP(include_port_in_address);
 ATOM_MAP(use_provisional_proxies);
+ATOM_MAP(report_conflicting_keys);
 
 
 // Streaming mode

--- a/c_src/main.c
+++ b/c_src/main.c
@@ -946,6 +946,10 @@ erlfdb_transaction_set_option(
         option = FDB_TR_OPTION_SIZE_LIMIT;
     } else if(IS_ATOM(argv[1], use_provisional_proxies)) {
         option = FDB_TR_OPTION_USE_PROVISIONAL_PROXIES;
+#if FDB_API_VERSION > 620
+    } else if(IS_ATOM(argv[1], report_conflicting_keys)) {
+        option = FDB_TR_OPTION_REPORT_CONFLICTING_KEYS;
+#endif
     } else {
         return enif_make_badarg(env);
     }

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -115,6 +115,9 @@
     % Locality
     get_addresses_for_key/2,
 
+    % Get conflict information
+    get_conflicting_keys/1,
+
     % Misc
     on_error/2,
     error_predicate/2,
@@ -627,6 +630,12 @@ get_addresses_for_key(?IS_TX = Tx, Key) ->
 
 get_addresses_for_key(?IS_SS = SS, Key) ->
     get_addresses_for_key(?GET_TX(SS), Key).
+
+
+get_conflicting_keys(?IS_TX = Tx) ->
+    StartKey = <<16#FF, 16#FF, "/transaction/conflicting_keys/">>,
+    EndKey = <<16#FF, 16#FF, "/transaction/conflicting_keys/", 16#FF>>,
+    get_range(Tx, StartKey, EndKey).
 
 
 on_error(?IS_TX = Tx, {erlfdb_error, ErrorCode}) ->


### PR DESCRIPTION
Transactions that fail due to a conflict can be hard to debug. This
exposes a recent feature that reports keys that were in conflict if a
transaction has to be retried due to a conflict.