### PR TITLE
Allow fold_range_wait in snapshot mode

### DIFF
--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -402,7 +402,10 @@ fold_range_future(?IS_SS = SS, StartKey, EndKey, Options) ->
 fold_range_wait(?IS_TX = Tx, ?IS_FOLD_FUTURE = FI, Fun, Acc) ->
     fold_range_int(Tx, FI, fun(Rows, InnerAcc) ->
         lists:foldl(Fun, InnerAcc, Rows)
-    end, Acc).
+    end, Acc);
+
+fold_range_wait(?IS_SS = SS, ?IS_FOLD_FUTURE = FI, Fun, Acc) ->
+    fold_range_wait(?GET_TX(SS), FI, Fun, Acc).
 
 
 set(?IS_DB = Db, Key, Value) ->


### PR DESCRIPTION
This is just a convenience function in case the calling code happens to supply an erlfdb_snapshot structure instead of an erlfdb_transaction. It has no actual effect on the semantics since this is merely waiting on the previously-created future.