### PR TITLE
Add /usr/local/{include|lib} to CFLAGS/LDFLAGS

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,12 +6,12 @@
 
 {port_env, [
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall -Werror"},
+        "CFLAGS", "$CFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall -Werror"},
+        "CXXFLAGS", "$CXXFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "LDFLAGS", "$LDFLAGS -lfdb_c"}
+        "LDFLAGS", "$LDFLAGS -L/usr/local/lib -lfdb_c"}
 ]}.
 
 {eunit_opts, [


### PR DESCRIPTION
This will allow compilation of `erlfdb` on *BSDs, with no other changes required.

`gmake check` is still not passing on `main` for CouchDB due to this error, I could use some help debugging it:

```
Cannot start application 'fabric', reason {{shutdown,
                                            {failed_to_start_child,
                                             fabric2_server,
                                             {fdbserver_bin_not_found,
                                              [{erlfdb_util,
                                                find_fdbserver_bin,1,
                                                [{file,"src/erlfdb_util.erl"},
                                                 {line,188}]},
                                               {erlfdb_util,
                                                init_test_cluster_int,1,
                                                [{file,"src/erlfdb_util.erl"},
                                                 {line,115}]},
                                               {erlfdb_util,get_test_db,1,
                                                [{file,"src/erlfdb_util.erl"},
                                                 {line,37}]},
                                               {fabric2_server,
                                                get_db_and_cluster,1,
                                                [{file,
                                                  "src/fabric2_server.erl"},
                                                 {line,213}]},
                                               {fabric2_server,init,1,
                                                [{file,
                                                  "src/fabric2_server.erl"},
                                                 {line,133}]},
                                               {gen_server,init_it,2,
                                                [{file,"gen_server.erl"},
                                                 {line,374}]},
                                               {gen_server,init_it,6,
                                                [{file,"gen_server.erl"},
                                                 {line,342}]},
                                               {proc_lib,init_p_do_apply,3,
                                                [{file,"proc_lib.erl"},
                                                 {line,249}]}]}}},
                                           {fabric2_app,start,[normal,[]]}}
```

but I'm not really sure how to look at this further.

A new version tag will need to be struck and a `rebar.config.script` update in `apache/couchdb` after this lands.