### PR TITLE
look in /usr/local/bin/ before /usr/local/sbin/

### DIFF
--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -177,6 +177,7 @@ find_fdbserver_bin(Options) ->
         undefined ->
             [
                 <<"/usr/sbin/fdbserver">>,
+                <<"/usr/local/bin/fdbserver">>,
                 <<"/usr/local/sbin/fdbserver">>,
                 <<"/usr/local/libexec/fdbserver">>
             ];


### PR DESCRIPTION
according to [heir(7)](https://man.freebsd.org/cgi/hier) /sbin/ is for binaries fundamental to single-user
and multi-user environments, which fdb is definitely not. The fdb packages
(for FreeBSD at least) leave their binaries in `/usr/local/bin/fdb*`