### PR TITLE
Make monitor.py use /usr/bin/env python3

### DIFF
--- a/priv/monitor.py
+++ b/priv/monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Previously it was set to `/usr/bin/python`, however on later versions
of Ubuntu and other OSes `/usr/bin/python` is missing. Users may install the
`python-is-python3` package but that is not ideal.