### PR TITLE
Make the default wait timeout infinity (continued)

### DIFF
--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -253,7 +253,7 @@ wait(?IS_FUTURE = Future, Options) ->
             flush_future_message(Future),
             Result;
         false ->
-            Timeout = erlfdb_util:get(Options, timeout, 5000),
+            Timeout = erlfdb_util:get(Options, timeout, infinity),
             {erlfdb_future, MsgRef, _Res} = Future,
             receive
                 {MsgRef, ready} -> get(Future)


### PR DESCRIPTION
This the continuation of https://github.com/apache/couchdb-erlfdb/pull/22. There, we updated only one `after` clause and forgot the other. The reasoning is the same as before -- make erlfdb behave consistent with other FDB clients which
do not have top level client-side timeouts for futures.