### PR TITLE
Ensure application environment is loaded

### DIFF
--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -48,6 +48,8 @@ get_test_db(Options) ->
 
 
 init_test_cluster(Options) ->
+    % Hack to ensure erlfdb app environment is loaded during unit tests
+    ok = application:ensure_started(erlfdb),
     case application:get_env(erlfdb, test_cluster_file) of
         {ok, ClusterFile} ->
             {ok, ClusterFile};


### PR DESCRIPTION
erlfdb is a library application, but starting the app is still required to make the application environment variables accessible.
Without this hack the `test_cluster_file` setting has no effect during eunit test executions.