### PR TITLE
Add a dev container configuration for VS Code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,10 +11,18 @@ FROM erlang:${ERLANG_VERSION}
 # in order to use it again to download the FDB client package
 ARG FDB_VERSION
 
+# Install the FDB client used underneath erlfdb
 RUN set -ex; \
     wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
     mkdir /var/lib/foundationdb; \
     dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb
+
+# FDB bindings tester uses the Python bindings
+RUN set -ex; \
+    wget https://www.foundationdb.org/downloads/${FDB_VERSION}/bindings/python/foundationdb-${FDB_VERSION}.tar.gz; \
+    tar zxf foundationdb-${FDB_VERSION}.tar.gz; \
+    cd foundationdb-${FDB_VERSION}; \
+    python3 setup.py install
 
 # `dig` is used by the script that creates the FDB cluster file
 RUN set -ex; \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+ARG FDB_VERSION
+ARG ERLANG_VERSION
+
+# Grab fdbcli and client library from same image as server
+FROM foundationdb/foundationdb:${FDB_VERSION} as fdb
+
+# Debian image with Erlang installed (we need elixir for test suite)
+FROM erlang:${ERLANG_VERSION}
+
+# The FROM directive above sweeps out the ARGs so we need to re-declare here
+# in order to use it again to download the FDB client package
+ARG FDB_VERSION
+
+RUN set -ex; \
+    wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
+    mkdir /var/lib/foundationdb; \
+    dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb
+
+# `dig` is used by the script that creates the FDB cluster file
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        dnsutils
+
+COPY --from=fdb /var/fdb/scripts/create_cluster_file.bash /usr/local/bin/
+
+CMD sleep infinity

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,12 +17,22 @@ RUN set -ex; \
     mkdir /var/lib/foundationdb; \
     dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb
 
-# FDB bindings tester uses the Python bindings
+# FDB bindings tester uses the Python bindings; install them from a
+# package to avoid building FDB from source
+# TODO FDB 6.3+ uses python3, we'll need to update it here
 RUN set -ex; \
     wget https://www.foundationdb.org/downloads/${FDB_VERSION}/bindings/python/foundationdb-${FDB_VERSION}.tar.gz; \
     tar zxf foundationdb-${FDB_VERSION}.tar.gz; \
     cd foundationdb-${FDB_VERSION}; \
-    python3 setup.py install
+    python setup.py install
+
+# Clone FoundationDB repo to retrieve bindings tester package and
+# patch it to support erlfdb
+COPY add_erlang_bindings.patch /tmp/
+RUN set -ex; \
+    git clone --branch ${FDB_VERSION} --single-branch https://github.com/apple/foundationdb /usr/src/foundationdb; \
+    cd /usr/src/foundationdb; \
+    git apply /tmp/add_erlang_bindings.patch
 
 # `dig` is used by the script that creates the FDB cluster file
 RUN set -ex; \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ ARG ERLANG_VERSION
 # Grab fdbcli and client library from same image as server
 FROM foundationdb/foundationdb:${FDB_VERSION} as fdb
 
-# Debian image with Erlang installed (we need elixir for test suite)
+# Debian image with Erlang installed
 FROM erlang:${ERLANG_VERSION}
 
 # The FROM directive above sweeps out the ARGs so we need to re-declare here
@@ -15,7 +15,8 @@ ARG FDB_VERSION
 RUN set -ex; \
     wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
     mkdir /var/lib/foundationdb; \
-    dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb
+    dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
+    rm foundationdb-clients_${FDB_VERSION}-1_amd64.deb
 
 # FDB bindings tester uses the Python bindings; install them from a
 # package to avoid building FDB from source
@@ -24,13 +25,14 @@ RUN set -ex; \
     wget https://www.foundationdb.org/downloads/${FDB_VERSION}/bindings/python/foundationdb-${FDB_VERSION}.tar.gz; \
     tar zxf foundationdb-${FDB_VERSION}.tar.gz; \
     cd foundationdb-${FDB_VERSION}; \
-    python setup.py install
+    python setup.py install; \
+    rm ../foundationdb-${FDB_VERSION}.tar.gz
 
 # Clone FoundationDB repo to retrieve bindings tester package and
 # patch it to support erlfdb
 COPY add_erlang_bindings.patch /tmp/
 RUN set -ex; \
-    git clone --branch ${FDB_VERSION} --single-branch https://github.com/apple/foundationdb /usr/src/foundationdb; \
+    git clone --branch ${FDB_VERSION} --depth 1 https://github.com/apple/foundationdb /usr/src/foundationdb; \
     cd /usr/src/foundationdb; \
     git apply /tmp/add_erlang_bindings.patch
 
@@ -38,7 +40,8 @@ RUN set -ex; \
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        dnsutils
+        dnsutils; \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=fdb /var/fdb/scripts/create_cluster_file.bash /usr/local/bin/
 

--- a/.devcontainer/add_erlang_bindings.patch
+++ b/.devcontainer/add_erlang_bindings.patch
@@ -1,0 +1,24 @@
+diff --git a/bindings/bindingtester/__init__.py b/bindings/bindingtester/__init__.py
+index 75454625c..fa20d37ab 100644
+--- a/bindings/bindingtester/__init__.py
++++ b/bindings/bindingtester/__init__.py
+@@ -22,7 +22,6 @@ import math
+ import sys
+ import os
+ 
+-sys.path[:0] = [os.path.join(os.path.dirname(__file__), '..', '..', 'bindings', 'python')]
+ 
+ import util
+ 
+diff --git a/bindings/bindingtester/known_testers.py b/bindings/bindingtester/known_testers.py
+index 2c5211a3d..30c1fafdc 100644
+--- a/bindings/bindingtester/known_testers.py
++++ b/bindings/bindingtester/known_testers.py
+@@ -57,6 +57,7 @@ _java_cmd = 'java -ea -cp %s:%s com.apple.foundationdb.test.' % (
+ 
+ # We could set min_api_version lower on some of these if the testers were updated to support them
+ testers = {
++    'erlang': Tester('erlang', '/usr/src/erlfdb/test/tester.es', 2040, 610, MAX_API_VERSION, types=ALL_TYPES),
+     'python': Tester('python', 'python ' + _absolute_path('python/tests/tester.py'), 2040, 23, MAX_API_VERSION, types=ALL_TYPES),
+     'python3': Tester('python3', 'python3 ' + _absolute_path('python/tests/tester.py'), 2040, 23, MAX_API_VERSION, types=ALL_TYPES),
+     'ruby': Tester('ruby', _absolute_path('ruby/tests/tester.rb'), 2040, 23, MAX_API_VERSION),

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "dockerComposeFile": "docker-compose.yaml",
+    "service": "erlfdb",
+    "workspaceFolder": "/usr/src/erlfdb",
+
+    // Needs to run at start to translate service name into coordinator IP
+    "postStartCommand": ["bash", "/usr/local/bin/create_cluster_file.bash"],
+
+    "extensions": [
+        "erlang-ls.erlang-ls"
+    ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,13 @@
     "service": "erlfdb",
     "workspaceFolder": "/usr/src/erlfdb",
 
-    // Needs to run at start to translate service name into coordinator IP
-    "postStartCommand": ["bash", "/usr/local/bin/create_cluster_file.bash"],
+    // Create the fdb.cluster file, resolving the FDB service name to an IP
+    "onCreateCommand": ["bash", "/usr/local/bin/create_cluster_file.bash"],
+
+    // Initialize a new database. If the erlfdb container is being re-created,
+    // a database may already exist. In that case an error message will be
+    // printed in the logs and the existing database will be reused.
+    "postCreateCommand": "fdbcli --exec 'configure new single ssd'",
 
     "extensions": [
         "erlang-ls.erlang-ls"

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  erlfdb:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        ERLANG_VERSION: "24"
+
+        # This should always match the value in fdb.image
+        FDB_VERSION: "6.3.18"
+
+    environment:
+      # This needs to match the name of the FoundationDB service below
+      FDB_COORDINATOR: fdb
+
+      # The location where the Dockerfile installs the FDB cluster file
+      # retrieved from the `fdb` image. CouchDB looks for the cluster file in
+      # this location by default. If you want to install it somewhere else you
+      # you need to change "[erlfdb] cluster_file" and ERL_ZFLAGS to match.
+      FDB_CLUSTER_FILE: /usr/local/etc/foundationdb/fdb.cluster
+
+      # The test suite will default to trying to start its own fdbserver
+      # process. This environment variable tells it to use the fdbserver
+      # running in the `fdb` image instead. Quite a hacky solution.
+      ERL_ZFLAGS: "-erlfdb test_cluster_file <<\\\"/usr/local/etc/foundationdb/fdb.cluster\\\">>"
+
+    volumes:
+      # Mounts the project folder to '/usr/src/erlfdb'. The target path inside
+      # the container should match what your application expects. In this case,
+      # the compose file is in a sub-folder, so you will mount '..'. You would
+      # then reference this path as the 'workspaceFolder' in
+      # '.devcontainer/devcontainer.json' so VS Code starts here.
+      - ..:/usr/src/erlfdb:cached
+
+    network_mode: service:fdb
+
+  fdb:
+    image: foundationdb/foundationdb:6.3.18

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
         ERLANG_VERSION: "24"
 
         # This should always match the value in fdb.image
-        FDB_VERSION: "6.3.18"
+        FDB_VERSION: "6.2.29"
 
     environment:
       # This needs to match the name of the FoundationDB service below
@@ -35,4 +35,4 @@ services:
     network_mode: service:fdb
 
   fdb:
-    image: foundationdb/foundationdb:6.3.18
+    image: foundationdb/foundationdb:6.2.29

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
         ERLANG_VERSION: "24"
 
         # This should always match the value in fdb.image
-        FDB_VERSION: "6.2.29"
+        FDB_VERSION: "6.2.30"
 
     environment:
       # This needs to match the name of the FoundationDB service below
@@ -35,4 +35,4 @@ services:
     network_mode: service:fdb
 
   fdb:
-    image: foundationdb/foundationdb:6.2.29
+    image: foundationdb/foundationdb:6.2.30

--- a/BINDING_TESTER.md
+++ b/BINDING_TESTER.md
@@ -9,7 +9,7 @@ files to register Erlang as a known binding. Assuming erlfdb has been built
 using `make`; the bindings tests be run directly via
 
 ```bash
-ERL_LIBS=/usr/src/erlfdb/ /usr/src/foundationdb/bindings/bindingtester/bindingtester.py erlang
+ERL_LIBS=/usr/src/erlfdb/_build/test/lib/erlfdb/ /usr/src/foundationdb/bindings/bindingtester/bindingtester.py erlang
 ```
 
 # Manual Approach
@@ -78,7 +78,7 @@ Database created
 
 ```bash
 $ cd /Users/davisp/github/davisp/foundationdb/bindings/bindingtester
-$ ERL_LIBS=/Users/davisp/github/labs-cloudant/couchdb-erlfdb/ PYTHONPATH=/Users/davisp/github/davisp/foundationdb/_build/bindings/python/ ./bindingtester.py --cluster-file /Users/davisp/tmp/fdbtest/fdb.cluster erlang
+$ ERL_LIBS=/Users/davisp/github/labs-cloudant/couchdb-erlfdb/_build/test/lib/erlfdb/ PYTHONPATH=/Users/davisp/github/davisp/foundationdb/_build/bindings/python/ ./bindingtester.py --cluster-file /Users/davisp/tmp/fdbtest/fdb.cluster erlang
 ```
 
 # Testing Notes

--- a/BINDING_TESTER.md
+++ b/BINDING_TESTER.md
@@ -1,6 +1,19 @@
 Running the bindingstester
 ===
 
+# Easy Button: devcontainer
+
+The image build takes care of setting up an environment where the Erlang
+bindings can be tested. It clones the FDB repo and patches the necessary
+files to register Erlang as a known binding. Assuming erlfdb has been built
+using `make`; the bindings tests be run directly via
+
+```bash
+ERL_LIBS=/usr/src/erlfdb/ /usr/src/foundationdb/bindings/bindingtester/bindingtester.py erlang
+```
+
+# Manual Approach
+
 This assumes that all FoundationDB dependencies are installed properly. See
 the FoundationDB documentation for information on the dependencies.
 
@@ -67,6 +80,8 @@ Database created
 $ cd /Users/davisp/github/davisp/foundationdb/bindings/bindingtester
 $ ERL_LIBS=/Users/davisp/github/labs-cloudant/couchdb-erlfdb/ PYTHONPATH=/Users/davisp/github/davisp/foundationdb/_build/bindings/python/ ./bindingtester.py --cluster-file /Users/davisp/tmp/fdbtest/fdb.cluster erlang
 ```
+
+# Testing Notes
 
 By default, `bindingtester.py` runs the `scripted.py` test which is a deterministic set of tests. To really try and soak test the bindings you should add the following command line parameters:
 

--- a/devcontainer.config
+++ b/devcontainer.config
@@ -1,0 +1,5 @@
+[
+    {erlfdb, [
+        {test_cluster_file, <<"/usr/local/etc/foundationdb/fdb.cluster">>}
+    ]}
+].

--- a/rebar.config
+++ b/rebar.config
@@ -30,6 +30,11 @@
 ]}.
 
 {profiles, [
+    {devcontainer, [
+        {eunit_opts, [
+            {sys_config, "devcontainer.config"}
+        ]}
+    ]},
     {win32_external_fdbserver, [
         {eunit_opts, [
             {sys_config, "win32_external_fdbserver.config"}

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -52,6 +52,8 @@ init_test_cluster(Options) ->
     ok = application:ensure_started(erlfdb),
     case application:get_env(erlfdb, test_cluster_file) of
         {ok, ClusterFile} ->
+            % Create a database if one does not already exist
+            init_fdb_db(ClusterFile, Options),
             {ok, ClusterFile};
         undefined ->
             init_test_cluster_int(Options)

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -52,8 +52,6 @@ init_test_cluster(Options) ->
     ok = application:ensure_started(erlfdb),
     case application:get_env(erlfdb, test_cluster_file) of
         {ok, ClusterFile} ->
-            % Create a database if one does not already exist
-            init_fdb_db(ClusterFile, Options),
             {ok, ClusterFile};
         undefined ->
             init_test_cluster_int(Options)


### PR DESCRIPTION
This creates a development environment with a FoundationDB server and an erlfdb client in two containers, sharing a network through Docker Compose.

It uses the FDB image published to Docker Hub for the FDB container, and downloads the FDB client packages from foundationdb.org to provide the development headers and libraries. Once the Docker Compose setup is running, VS Code executes the `create_cluster_file.bash` script to write down a cluster file containing the IP address in the compose network where the FDB service can be found.

I also did some work to make it easy to run the bindings tests following Paul's original instructions. The Dockerfile does a shallow clone of the FoundationDB repo and applies a patch file to register our Escript tester as a known tester. It also install the Python bindings so we don't need to build FDB from source in order to execute the tests. With that it's possible to run the bindings tests out of the box:

```
make
ERL_LIBS=/usr/src/erlfdb/ /usr/src/foundationdb/bindings/bindingtester/bindingtester.py erlang
```

## Requests for Reviewer

~I did make one change to erlfdb itself that's worth discussing. I made it so that the test suite will try to run `configure new single ssd` even when a user supplied a custom `test_cluster_file` in the erlfdb application environment. Previously we only ran that command when the test suite was starting its own server. This is a safe operation when a cluster is already properly configured, but if a cluster is in a misconfigured state the command could cause the cluster to drop whatever data it might have been storing previously.~

I figured out what I think is a better approach here using the .devcontainer lifecycle hooks. Now this PR does not change any lines of actual erlfdb code and erlfdb will not try to configure a new database in a user's external FDB server if that server is selected via the `test_cluster_file`.

## Testing Recommendation

Open the repo in VS Code and it should offer to reopen inside the container. Open a terminal in the editor once the container is build and run `make`; erlfdb should build and run unit tests successfully. The run the bindings tests as indicated above.