### PR TITLE
Format code using erlfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           otp-version: '24'
           rebar3-version: '3.17'
+      - name: Enforce coding style
+        run: rebar3 fmt --check
       - name: Compile
         run: rebar3 compile
       - name: EUnit tests

--- a/include/erlfdb.hrl
+++ b/include/erlfdb.hrl
@@ -10,26 +10,27 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-
 -define(ERLFDB_ERROR(Reason), erlang:error({?MODULE, Reason})).
-
 
 -define(ERLFDB_PACK(Tuple), erlfdb_tuple:pack(Tuple)).
 -define(ERLFDB_PACK(Prefix, Tuple), erlfdb_tuple:pack(Tuple, Prefix)).
 
 -define(ERLFDB_RANGE(Prefix),
-        erlfdb_subspace:range(erlfdb_subspace:create({}, Prefix))).
+    erlfdb_subspace:range(erlfdb_subspace:create({}, Prefix))
+).
 -define(ERLFDB_RANGE(Prefix, Term),
-        erlfdb_subspace:range(erlfdb_subspace:create({Term}, Prefix))).
+    erlfdb_subspace:range(erlfdb_subspace:create({Term}, Prefix))
+).
 
 -define(ERLFDB_EXTEND(Prefix, Term), erlfdb_tuple:pack({Term}, Prefix)).
 
--define(ERLFDB_EXTRACT(Prefix, Packed), (fun() ->
+-define(ERLFDB_EXTRACT(Prefix, Packed),
+    (fun() ->
         __PrefixLen = size(Prefix),
         <<Prefix:__PrefixLen/binary, __Tail/binary>> = Packed,
         erlfdb_tuple:unpack(__Tail)
-    end)()).
-
+    end)()
+).
 
 % Most of the retriable FDB errors. The list of errors can be generated with
 % something like [erlfdb:get_error_string(C) || C <- lists:seq(1, 5000),
@@ -54,6 +55,7 @@
 % include ?TRANSACTION_TIMED_OUT. In some cases it may make sense to also
 % consider that error as retryable.
 %
+%% erlfmt-ignore
 -define(ERLFDB_IS_RETRYABLE(Code), (
     (Code == ?ERLFDB_TRANSACTION_TOO_OLD) orelse
     (Code == ?ERLFDB_FUTURE_VERSION) orelse

--- a/rebar.config
+++ b/rebar.config
@@ -18,19 +18,37 @@
 ]}.
 
 {port_env, [
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CFLAGS", "$CFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"},
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CXXFLAGS", "$CXXFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"},
-    {"win32",
-        "CFLAGS", "$CFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"},
-    {"win32",
-        "CXXFLAGS", "$CXXFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"},
+    {
+        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
+        "CFLAGS",
+        "$CFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"
+    },
+    {
+        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
+        "CXXFLAGS",
+        "$CXXFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"
+    },
+    {
+        "win32",
+        "CFLAGS",
+        "$CFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"
+    },
+    {
+        "win32",
+        "CXXFLAGS",
+        "$CXXFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"
+    },
 
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "LDFLAGS", "$LDFLAGS -L/usr/local/lib -lfdb_c"},
-    {"win32",
-        "LDFLAGS", "$LDFLAGS /LIBPATH:\"c:/Program Files/foundationdb/lib/foundationdb\" fdb_c.lib"}
+    {
+        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
+        "LDFLAGS",
+        "$LDFLAGS -L/usr/local/lib -lfdb_c"
+    },
+    {
+        "win32",
+        "LDFLAGS",
+        "$LDFLAGS /LIBPATH:\"c:/Program Files/foundationdb/lib/foundationdb\" fdb_c.lib"
+    }
 ]}.
 
 {profiles, [

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,10 @@
     pc
 ]}.
 
+{project_plugins, [
+    erlfmt
+]}.
+
 {provider_hooks, [
     {pre, [
         {compile, {pc, compile}},

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -12,9 +12,7 @@
 
 -module(erlfdb).
 
-
 -compile({no_auto_import, [get/1]}).
-
 
 -export([
     open/0,
@@ -125,7 +123,6 @@
     get_error_string/1
 ]).
 
-
 -define(IS_FUTURE, {erlfdb_future, _, _}).
 -define(IS_FOLD_FUTURE, {fold_info, _, _}).
 -define(IS_DB, {erlfdb_database, _}).
@@ -133,7 +130,6 @@
 -define(IS_SS, {erlfdb_snapshot, _}).
 -define(GET_TX(SS), element(2, SS)).
 -define(ERLFDB_ERROR, '$erlfdb_error').
-
 
 -record(fold_st, {
     start_key,
@@ -146,71 +142,53 @@
     reverse
 }).
 
-
 open() ->
     open(<<>>).
-
 
 open(ClusterFile) ->
     erlfdb_nif:create_database(ClusterFile).
 
-
 create_transaction(?IS_DB = Db) ->
     erlfdb_nif:database_create_transaction(Db).
-
 
 transactional(?IS_DB = Db, UserFun) when is_function(UserFun, 1) ->
     clear_erlfdb_error(),
     Tx = create_transaction(Db),
     do_transaction(Tx, UserFun);
-
 transactional(?IS_TX = Tx, UserFun) when is_function(UserFun, 1) ->
     UserFun(Tx);
-
 transactional(?IS_SS = SS, UserFun) when is_function(UserFun, 1) ->
     UserFun(SS).
 
-
 snapshot(?IS_TX = Tx) ->
     {erlfdb_snapshot, Tx};
-
 snapshot(?IS_SS = SS) ->
     SS.
-
 
 set_option(DbOrTx, Option) ->
     set_option(DbOrTx, Option, <<>>).
 
-
 set_option(?IS_DB = Db, DbOption, Value) ->
     erlfdb_nif:database_set_option(Db, DbOption, Value);
-
 set_option(?IS_TX = Tx, TxOption, Value) ->
     erlfdb_nif:transaction_set_option(Tx, TxOption, Value).
-
 
 commit(?IS_TX = Tx) ->
     erlfdb_nif:transaction_commit(Tx).
 
-
 reset(?IS_TX = Tx) ->
     ok = erlfdb_nif:transaction_reset(Tx).
 
-
 cancel(?IS_FOLD_FUTURE = FoldInfo) ->
     cancel(FoldInfo, []);
-
 cancel(?IS_FUTURE = Future) ->
     cancel(Future, []);
-
 cancel(?IS_TX = Tx) ->
     ok = erlfdb_nif:transaction_cancel(Tx).
-
 
 cancel(?IS_FOLD_FUTURE = FoldInfo, Options) ->
     {fold_info, _St, Future} = FoldInfo,
     cancel(Future, Options);
-
 cancel(?IS_FUTURE = Future, Options) ->
     ok = erlfdb_nif:future_cancel(Future),
     case erlfdb_util:get(Options, flush, false) of
@@ -218,18 +196,14 @@ cancel(?IS_FUTURE = Future, Options) ->
         false -> ok
     end.
 
-
 is_ready(?IS_FUTURE = Future) ->
     erlfdb_nif:future_is_ready(Future).
-
 
 get_error(?IS_FUTURE = Future) ->
     erlfdb_nif:future_get_error(Future).
 
-
 get(?IS_FUTURE = Future) ->
     erlfdb_nif:future_get(Future).
-
 
 block_until_ready(?IS_FUTURE = Future) ->
     {erlfdb_future, MsgRef, _FRef} = Future,
@@ -237,13 +211,10 @@ block_until_ready(?IS_FUTURE = Future) ->
         {MsgRef, ready} -> ok
     end.
 
-
 wait(?IS_FUTURE = Future) ->
     wait(Future, []);
-
 wait(Ready) ->
     Ready.
-
 
 wait(?IS_FUTURE = Future, Options) ->
     case is_ready(Future) of
@@ -261,18 +232,14 @@ wait(?IS_FUTURE = Future, Options) ->
                 erlang:error({timeout, Future})
             end
     end;
-
 wait(Ready, _) ->
     Ready.
-
 
 wait_for_any(Futures) ->
     wait_for_any(Futures, []).
 
-
 wait_for_any(Futures, Options) ->
     wait_for_any(Futures, Options, []).
-
 
 wait_for_any(Futures, Options, ResendQ) ->
     Timeout = erlfdb_util:get(Options, timeout, infinity),
@@ -280,246 +247,213 @@ wait_for_any(Futures, Options, ResendQ) ->
         {MsgRef, ready} = Msg ->
             case lists:keyfind(MsgRef, 2, Futures) of
                 ?IS_FUTURE = Future ->
-                    lists:foreach(fun(M) ->
-                        self() ! M
-                    end, ResendQ),
+                    lists:foreach(
+                        fun(M) ->
+                            self() ! M
+                        end,
+                        ResendQ
+                    ),
                     Future;
                 _ ->
                     wait_for_any(Futures, Options, [Msg | ResendQ])
             end
     after Timeout ->
-        lists:foreach(fun(M) ->
-            self() ! M
-        end, ResendQ),
+        lists:foreach(
+            fun(M) ->
+                self() ! M
+            end,
+            ResendQ
+        ),
         erlang:error({timeout, Futures})
     end.
 
-
 wait_for_all(Futures) ->
     wait_for_all(Futures, []).
-
 
 wait_for_all(Futures, Options) ->
     % Same as wait for all. We might want to
     % handle timeouts here so we have a single
     % timeout for all future waiting.
-    lists:map(fun(Future) ->
-        wait(Future, Options)
-    end, Futures).
-
+    lists:map(
+        fun(Future) ->
+            wait(Future, Options)
+        end,
+        Futures
+    ).
 
 get(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
         wait(get(Tx, Key))
     end);
-
 get(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_get(Tx, Key, false);
-
 get(?IS_SS = SS, Key) ->
     get_ss(?GET_TX(SS), Key).
 
-
 get_ss(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_get(Tx, Key, true);
-
 get_ss(?IS_SS = SS, Key) ->
     get_ss(?GET_TX(SS), Key).
-
 
 get_key(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
         wait(get_key(Tx, Key))
     end);
-
 get_key(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_get_key(Tx, Key, false);
-
 get_key(?IS_SS = SS, Key) ->
     get_key_ss(?GET_TX(SS), Key).
-
 
 get_key_ss(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_get_key(Tx, Key, true).
 
-
 get_range(DbOrTx, StartKey, EndKey) ->
     get_range(DbOrTx, StartKey, EndKey, []).
-
 
 get_range(?IS_DB = Db, StartKey, EndKey, Options) ->
     transactional(Db, fun(Tx) ->
         get_range(Tx, StartKey, EndKey, Options)
     end);
-
 get_range(?IS_TX = Tx, StartKey, EndKey, Options) ->
     Fun = fun(Rows, Acc) -> [Rows | Acc] end,
     Chunks = fold_range_int(Tx, StartKey, EndKey, Fun, [], Options),
     lists:flatten(lists:reverse(Chunks));
-
 get_range(?IS_SS = SS, StartKey, EndKey, Options) ->
     get_range(?GET_TX(SS), StartKey, EndKey, [{snapshot, true} | Options]).
 
-
 get_range_startswith(DbOrTx, Prefix) ->
     get_range_startswith(DbOrTx, Prefix, []).
-
 
 get_range_startswith(DbOrTx, Prefix, Options) ->
     StartKey = Prefix,
     EndKey = erlfdb_key:strinc(Prefix),
     get_range(DbOrTx, StartKey, EndKey, Options).
 
-
 fold_range(DbOrTx, StartKey, EndKey, Fun, Acc) ->
     fold_range(DbOrTx, StartKey, EndKey, Fun, Acc, []).
-
 
 fold_range(?IS_DB = Db, StartKey, EndKey, Fun, Acc, Options) ->
     transactional(Db, fun(Tx) ->
         fold_range(Tx, StartKey, EndKey, Fun, Acc, Options)
     end);
-
 fold_range(?IS_TX = Tx, StartKey, EndKey, Fun, Acc, Options) ->
-    fold_range_int(Tx, StartKey, EndKey, fun(Rows, InnerAcc) ->
-        lists:foldl(Fun, InnerAcc, Rows)
-    end, Acc, Options);
-
+    fold_range_int(
+        Tx,
+        StartKey,
+        EndKey,
+        fun(Rows, InnerAcc) ->
+            lists:foldl(Fun, InnerAcc, Rows)
+        end,
+        Acc,
+        Options
+    );
 fold_range(?IS_SS = SS, StartKey, EndKey, Fun, Acc, Options) ->
     SSOptions = [{snapshot, true} | Options],
     fold_range(?GET_TX(SS), StartKey, EndKey, Fun, Acc, SSOptions).
 
-
 fold_range_future(?IS_TX = Tx, StartKey, EndKey, Options) ->
     St = options_to_fold_st(StartKey, EndKey, Options),
     fold_range_future_int(Tx, St);
-
 fold_range_future(?IS_SS = SS, StartKey, EndKey, Options) ->
     SSOptions = [{snapshot, true} | Options],
     fold_range_future(?GET_TX(SS), StartKey, EndKey, SSOptions).
 
-
 fold_range_wait(?IS_TX = Tx, ?IS_FOLD_FUTURE = FI, Fun, Acc) ->
-    fold_range_int(Tx, FI, fun(Rows, InnerAcc) ->
-        lists:foldl(Fun, InnerAcc, Rows)
-    end, Acc);
-
+    fold_range_int(
+        Tx,
+        FI,
+        fun(Rows, InnerAcc) ->
+            lists:foldl(Fun, InnerAcc, Rows)
+        end,
+        Acc
+    );
 fold_range_wait(?IS_SS = SS, ?IS_FOLD_FUTURE = FI, Fun, Acc) ->
     fold_range_wait(?GET_TX(SS), FI, Fun, Acc).
-
 
 set(?IS_DB = Db, Key, Value) ->
     transactional(Db, fun(Tx) ->
         set(Tx, Key, Value)
     end);
-
 set(?IS_TX = Tx, Key, Value) ->
     erlfdb_nif:transaction_set(Tx, Key, Value);
-
 set(?IS_SS = SS, Key, Value) ->
     set(?GET_TX(SS), Key, Value).
-
 
 clear(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
         clear(Tx, Key)
     end);
-
 clear(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_clear(Tx, Key);
-
 clear(?IS_SS = SS, Key) ->
     clear(?GET_TX(SS), Key).
-
 
 clear_range(?IS_DB = Db, StartKey, EndKey) ->
     transactional(Db, fun(Tx) ->
         clear_range(Tx, StartKey, EndKey)
     end);
-
 clear_range(?IS_TX = Tx, StartKey, EndKey) ->
     erlfdb_nif:transaction_clear_range(Tx, StartKey, EndKey);
-
 clear_range(?IS_SS = SS, StartKey, EndKey) ->
     clear_range(?GET_TX(SS), StartKey, EndKey).
-
 
 clear_range_startswith(?IS_DB = Db, Prefix) ->
     transactional(Db, fun(Tx) ->
         clear_range_startswith(Tx, Prefix)
     end);
-
 clear_range_startswith(?IS_TX = Tx, Prefix) ->
     EndKey = erlfdb_key:strinc(Prefix),
     erlfdb_nif:transaction_clear_range(Tx, Prefix, EndKey);
-
 clear_range_startswith(?IS_SS = SS, Prefix) ->
     clear_range_startswith(?GET_TX(SS), Prefix).
-
 
 add(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, add).
 
-
 bit_and(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, bit_and).
-
 
 bit_or(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, bit_or).
 
-
 bit_xor(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, bit_xor).
-
 
 min(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, min).
 
-
 max(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, max).
-
 
 byte_min(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, byte_min).
 
-
 byte_max(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, byte_max).
-
 
 set_versionstamped_key(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, set_versionstamped_key).
 
-
 set_versionstamped_value(DbOrTx, Key, Param) ->
     atomic_op(DbOrTx, Key, Param, set_versionstamped_value).
-
 
 atomic_op(?IS_DB = Db, Key, Param, Op) ->
     transactional(Db, fun(Tx) ->
         atomic_op(Tx, Key, Param, Op)
     end);
-
 atomic_op(?IS_TX = Tx, Key, Param, Op) ->
     erlfdb_nif:transaction_atomic_op(Tx, Key, Param, Op);
-
 atomic_op(?IS_SS = SS, Key, Param, Op) ->
     atomic_op(?GET_TX(SS), Key, Param, Op).
-
 
 watch(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
         watch(Tx, Key)
     end);
-
 watch(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_watch(Tx, Key);
-
 watch(?IS_SS = SS, Key) ->
     watch(?GET_TX(SS), Key).
-
 
 get_and_watch(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
@@ -528,13 +462,11 @@ get_and_watch(?IS_DB = Db, Key) ->
         {wait(KeyFuture), WatchFuture}
     end).
 
-
 set_and_watch(?IS_DB = Db, Key, Value) ->
     transactional(Db, fun(Tx) ->
         set(Tx, Key, Value),
         watch(Tx, Key)
     end).
-
 
 clear_and_watch(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
@@ -542,139 +474,102 @@ clear_and_watch(?IS_DB = Db, Key) ->
         watch(Tx, Key)
     end).
 
-
 add_read_conflict_key(TxObj, Key) ->
     add_read_conflict_range(TxObj, Key, <<Key/binary, 16#00>>).
-
 
 add_read_conflict_range(TxObj, StartKey, EndKey) ->
     add_conflict_range(TxObj, StartKey, EndKey, read).
 
-
 add_write_conflict_key(TxObj, Key) ->
     add_write_conflict_range(TxObj, Key, <<Key/binary, 16#00>>).
-
 
 add_write_conflict_range(TxObj, StartKey, EndKey) ->
     add_conflict_range(TxObj, StartKey, EndKey, write).
 
-
 add_conflict_range(?IS_TX = Tx, StartKey, EndKey, Type) ->
     erlfdb_nif:transaction_add_conflict_range(Tx, StartKey, EndKey, Type);
-
 add_conflict_range(?IS_SS = SS, StartKey, EndKey, Type) ->
     add_conflict_range(?GET_TX(SS), StartKey, EndKey, Type).
 
-
 set_read_version(?IS_TX = Tx, Version) ->
     erlfdb_nif:transaction_set_read_version(Tx, Version);
-
 set_read_version(?IS_SS = SS, Version) ->
     set_read_version(?GET_TX(SS), Version).
 
-
 get_read_version(?IS_TX = Tx) ->
     erlfdb_nif:transaction_get_read_version(Tx);
-
 get_read_version(?IS_SS = SS) ->
     get_read_version(?GET_TX(SS)).
 
-
 get_committed_version(?IS_TX = Tx) ->
     erlfdb_nif:transaction_get_committed_version(Tx);
-
 get_committed_version(?IS_SS = SS) ->
     get_committed_version(?GET_TX(SS)).
 
-
 get_versionstamp(?IS_TX = Tx) ->
     erlfdb_nif:transaction_get_versionstamp(Tx);
-
 get_versionstamp(?IS_SS = SS) ->
     get_versionstamp(?GET_TX(SS)).
 
-
 get_approximate_size(?IS_TX = Tx) ->
     erlfdb_nif:transaction_get_approximate_size(Tx);
-
 get_approximate_size(?IS_SS = SS) ->
     get_approximate_size(?GET_TX(SS)).
 
-
 get_next_tx_id(?IS_TX = Tx) ->
     erlfdb_nif:transaction_get_next_tx_id(Tx);
-
 get_next_tx_id(?IS_SS = SS) ->
     get_next_tx_id(?GET_TX(SS)).
 
-
 is_read_only(?IS_TX = Tx) ->
     erlfdb_nif:transaction_is_read_only(Tx);
-
 is_read_only(?IS_SS = SS) ->
     is_read_only(?GET_TX(SS)).
 
-
 has_watches(?IS_TX = Tx) ->
     erlfdb_nif:transaction_has_watches(Tx);
-
 has_watches(?IS_SS = SS) ->
     has_watches(?GET_TX(SS)).
 
-
 get_writes_allowed(?IS_TX = Tx) ->
     erlfdb_nif:transaction_get_writes_allowed(Tx);
-
 get_writes_allowed(?IS_SS = SS) ->
     get_writes_allowed(?GET_TX(SS)).
-
 
 get_addresses_for_key(?IS_DB = Db, Key) ->
     transactional(Db, fun(Tx) ->
         wait(get_addresses_for_key(Tx, Key))
     end);
-
 get_addresses_for_key(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_get_addresses_for_key(Tx, Key);
-
 get_addresses_for_key(?IS_SS = SS, Key) ->
     get_addresses_for_key(?GET_TX(SS), Key).
-
 
 get_conflicting_keys(?IS_TX = Tx) ->
     StartKey = <<16#FF, 16#FF, "/transaction/conflicting_keys/">>,
     EndKey = <<16#FF, 16#FF, "/transaction/conflicting_keys/", 16#FF>>,
     get_range(Tx, StartKey, EndKey).
 
-
 on_error(?IS_TX = Tx, {erlfdb_error, ErrorCode}) ->
     on_error(Tx, ErrorCode);
-
 on_error(?IS_TX = Tx, ErrorCode) ->
     erlfdb_nif:transaction_on_error(Tx, ErrorCode);
-
 on_error(?IS_SS = SS, Error) ->
     on_error(?GET_TX(SS), Error).
 
-
 error_predicate(Predicate, {erlfdb_error, ErrorCode}) ->
     error_predicate(Predicate, ErrorCode);
-
 error_predicate(Predicate, ErrorCode) ->
     erlfdb_nif:error_predicate(Predicate, ErrorCode).
-
 
 get_last_error() ->
     erlang:get(?ERLFDB_ERROR).
 
-
 get_error_string(ErrorCode) when is_integer(ErrorCode) ->
     erlfdb_nif:get_error(ErrorCode).
 
-
 clear_erlfdb_error() ->
     put(?ERLFDB_ERROR, undefined).
-
 
 do_transaction(?IS_TX = Tx, UserFun) ->
     try
@@ -684,22 +579,20 @@ do_transaction(?IS_TX = Tx, UserFun) ->
             false -> wait(commit(Tx), [{timeout, infinity}])
         end,
         Ret
-    catch error:{erlfdb_error, Code} ->
-        put(?ERLFDB_ERROR, Code),
-        wait(on_error(Tx, Code), [{timeout, infinity}]),
-        do_transaction(Tx, UserFun)
+    catch
+        error:{erlfdb_error, Code} ->
+            put(?ERLFDB_ERROR, Code),
+            wait(on_error(Tx, Code), [{timeout, infinity}]),
+            do_transaction(Tx, UserFun)
     end.
-
 
 fold_range_int(?IS_TX = Tx, StartKey, EndKey, Fun, Acc, Options) ->
     St = options_to_fold_st(StartKey, EndKey, Options),
     fold_range_int(Tx, St, Fun, Acc).
 
-
 fold_range_int(Tx, #fold_st{} = St, Fun, Acc) ->
     RangeFuture = fold_range_future_int(Tx, St),
     fold_range_int(Tx, RangeFuture, Fun, Acc);
-
 fold_range_int(Tx, ?IS_FOLD_FUTURE = FI, Fun, Acc) ->
     {fold_info, St, Future} = FI,
     #fold_st{
@@ -716,35 +609,46 @@ fold_range_int(Tx, ?IS_FOLD_FUTURE = FI, Fun, Acc) ->
 
     % If our limit is within the current set of
     % rows we need to truncate the list
-    Rows = if Limit == 0 orelse Limit > Count -> RawRows; true ->
-        lists:sublist(RawRows, Limit)
-    end,
+    Rows =
+        if
+            Limit == 0 orelse Limit > Count -> RawRows;
+            true -> lists:sublist(RawRows, Limit)
+        end,
 
     % Invoke our callback to update the accumulator
-    NewAcc = if Rows == [] -> Acc; true ->
-        Fun(Rows, Acc)
-    end,
+    NewAcc =
+        if
+            Rows == [] -> Acc;
+            true -> Fun(Rows, Acc)
+        end,
 
     % Determine if we have more rows to iterate
     Recurse = (Rows /= []) and (Limit == 0 orelse Limit > Count) and HasMore,
 
-    if not Recurse -> NewAcc; true ->
-        LastKey = element(1, lists:last(Rows)),
-        {NewStartKey, NewEndKey} = case Reverse /= 0 of
-            true ->
-                {StartKey, erlfdb_key:first_greater_or_equal(LastKey)};
-            false ->
-                {erlfdb_key:first_greater_than(LastKey), EndKey}
-        end,
-        NewSt = St#fold_st{
-            start_key = NewStartKey,
-            end_key = NewEndKey,
-            limit = if Limit == 0 -> 0; true -> Limit - Count end,
-            iteration = Iteration + 1
-        },
-        fold_range_int(Tx, NewSt, Fun, NewAcc)
+    if
+        not Recurse ->
+            NewAcc;
+        true ->
+            LastKey = element(1, lists:last(Rows)),
+            {NewStartKey, NewEndKey} =
+                case Reverse /= 0 of
+                    true ->
+                        {StartKey, erlfdb_key:first_greater_or_equal(LastKey)};
+                    false ->
+                        {erlfdb_key:first_greater_than(LastKey), EndKey}
+                end,
+            NewSt = St#fold_st{
+                start_key = NewStartKey,
+                end_key = NewEndKey,
+                limit =
+                    if
+                        Limit == 0 -> 0;
+                        true -> Limit - Count
+                    end,
+                iteration = Iteration + 1
+            },
+            fold_range_int(Tx, NewSt, Fun, NewAcc)
     end.
-
 
 fold_range_future_int(?IS_TX = Tx, #fold_st{} = St) ->
     #fold_st{
@@ -759,26 +663,26 @@ fold_range_future_int(?IS_TX = Tx, #fold_st{} = St) ->
     } = St,
 
     Future = erlfdb_nif:transaction_get_range(
-            Tx,
-            StartKey,
-            EndKey,
-            Limit,
-            TargetBytes,
-            StreamingMode,
-            Iteration,
-            Snapshot,
-            Reverse
-        ),
+        Tx,
+        StartKey,
+        EndKey,
+        Limit,
+        TargetBytes,
+        StreamingMode,
+        Iteration,
+        Snapshot,
+        Reverse
+    ),
 
     {fold_info, St, Future}.
 
-
 options_to_fold_st(StartKey, EndKey, Options) ->
-    Reverse = case erlfdb_util:get(Options, reverse, false) of
-        true -> 1;
-        false -> 0;
-        I when is_integer(I) -> I
-    end,
+    Reverse =
+        case erlfdb_util:get(Options, reverse, false) of
+            true -> 1;
+            false -> 0;
+            I when is_integer(I) -> I
+        end,
     #fold_st{
         start_key = erlfdb_key:to_selector(StartKey),
         end_key = erlfdb_key:to_selector(EndKey),
@@ -790,12 +694,10 @@ options_to_fold_st(StartKey, EndKey, Options) ->
         reverse = Reverse
     }.
 
-
 flush_future_message(?IS_FUTURE = Future) ->
     erlfdb_nif:future_silence(Future),
     {erlfdb_future, MsgRef, _Res} = Future,
     receive
         {MsgRef, ready} -> ok
-    after
-        0 -> ok
+    after 0 -> ok
     end.

--- a/src/erlfdb_directory.erl
+++ b/src/erlfdb_directory.erl
@@ -12,7 +12,6 @@
 
 -module(erlfdb_directory).
 
-
 -export([
     root/0,
     root/1,
@@ -59,31 +58,26 @@
     debug_nodes/2
 ]).
 
-
 -include("erlfdb.hrl").
-
 
 -define(LAYER_VERSION, {1, 0, 0}).
 -define(DEFAULT_NODE_PREFIX, <<16#FE>>).
 -define(SUBDIRS, 0).
 
-
 root() ->
     init_root([]).
-
 
 root(Options) ->
     init_root(Options).
 
-
 create_or_open(TxObj, Node, Path) ->
     create_or_open(TxObj, Node, Path, <<>>).
 
-
 create_or_open(TxObj, Node, PathIn, Layer) ->
     {Root, Path} = adj_path(Node, PathIn),
-    if Path /= [] -> ok; true ->
-        ?ERLFDB_ERROR({open_error, cannot_open_root})
+    if
+        Path /= [] -> ok;
+        true -> ?ERLFDB_ERROR({open_error, cannot_open_root})
     end,
     case create_or_open_int(TxObj, Root, Path, Layer) of
         #{is_absolute_root := true} ->
@@ -95,7 +89,6 @@ create_or_open(TxObj, Node, PathIn, Layer) ->
 create(TxObj, Node, Path) ->
     create(TxObj, Node, Path, []).
 
-
 create(TxObj, Node, PathIn, Options) ->
     {Root, Path} = adj_path(Node, PathIn),
     check_manual_node_name(Root, Options),
@@ -105,25 +98,22 @@ create(TxObj, Node, PathIn, Options) ->
         create_int(Tx, Root, Path, Layer, NodeName)
     end).
 
-
 open(TxObj, Node, Path) ->
     open(TxObj, Node, Path, []).
 
-
 open(TxObj, Node, PathIn, Options) ->
     {Root, Path} = adj_path(Node, PathIn),
-    if Path /= [] -> ok; true ->
-        ?ERLFDB_ERROR({open_error, cannot_open_root})
+    if
+        Path /= [] -> ok;
+        true -> ?ERLFDB_ERROR({open_error, cannot_open_root})
     end,
     erlfdb:transactional(TxObj, fun(Tx) ->
         Layer = erlfdb_util:get(Options, layer, <<>>),
         open_int(Tx, Root, Path, Layer)
     end).
 
-
 list(TxObj, Node) ->
     list(TxObj, Node, {}).
-
 
 list(TxObj, Node, PathIn) ->
     {Root, Path} = adj_path(Node, PathIn),
@@ -138,18 +128,19 @@ list(TxObj, Node, PathIn) ->
                 SDStart = <<Subdirs:SDLen/binary, 16#00>>,
                 SDEnd = <<Subdirs:SDLen/binary, 16#FF>>,
                 SubDirKVs = erlfdb:wait(erlfdb:get_range(Tx, SDStart, SDEnd)),
-                lists:map(fun({Key, NodeName}) ->
-                    {DName} = ?ERLFDB_EXTRACT(Subdirs, Key),
-                    ChildNode = init_node(Tx, ListNode, NodeName, DName),
-                    {DName, ChildNode}
-                end, SubDirKVs)
+                lists:map(
+                    fun({Key, NodeName}) ->
+                        {DName} = ?ERLFDB_EXTRACT(Subdirs, Key),
+                        ChildNode = init_node(Tx, ListNode, NodeName, DName),
+                        {DName, ChildNode}
+                    end,
+                    SubDirKVs
+                )
         end
     end).
 
-
 exists(TxObj, Node) ->
     exists(TxObj, Node, {}).
-
 
 exists(TxObj, Node, PathIn) ->
     %Root = get_root(Node),
@@ -165,7 +156,6 @@ exists(TxObj, Node, PathIn) ->
         end
     end).
 
-
 move(TxObj, Node, OldPathIn, NewPathIn) ->
     {Root, OldPath} = adj_path(Node, OldPathIn),
     {Root, NewPath} = adj_path(Node, NewPathIn),
@@ -176,12 +166,14 @@ move(TxObj, Node, OldPathIn, NewPathIn) ->
         OldNode = find(Tx, Root, OldPath),
         NewNode = find(Tx, Root, NewPath),
 
-        if OldNode /= not_found -> ok; true ->
-            ?ERLFDB_ERROR({move_error, missing_source, OldPath})
+        if
+            OldNode /= not_found -> ok;
+            true -> ?ERLFDB_ERROR({move_error, missing_source, OldPath})
         end,
 
-        if NewNode == not_found -> ok; true ->
-            ?ERLFDB_ERROR({move_error, target_exists, NewPath})
+        if
+            NewNode == not_found -> ok;
+            true -> ?ERLFDB_ERROR({move_error, target_exists, NewPath})
         end,
 
         {NewParentPath, [NewName]} = lists:split(length(NewPath) - 1, NewPath),
@@ -198,121 +190,102 @@ move(TxObj, Node, OldPathIn, NewPathIn) ->
         end
     end).
 
-
 move_to(_TxObj, #{is_absolute_root := true}, _NewPath) ->
     ?ERLFDB_ERROR({move_error, root_cannot_be_moved});
-
 move_to(TxObj, Node, NewAbsPathIn) ->
     Root = get_root_for_path(Node, []),
     RootPath = get_path(Root),
     RootPathLen = length(RootPath),
     NewAbsPath = path_init(NewAbsPathIn),
     IsPrefix = lists:prefix(RootPath, NewAbsPath),
-    if IsPrefix -> ok; true ->
-        ?ERLFDB_ERROR({move_error, partition_mismatch, RootPath, NewAbsPath})
+    if
+        IsPrefix -> ok;
+        true -> ?ERLFDB_ERROR({move_error, partition_mismatch, RootPath, NewAbsPath})
     end,
     NodePath = get_path(Node),
     SrcPath = lists:nthtail(RootPathLen, NodePath),
     TgtPath = lists:nthtail(RootPathLen, NewAbsPath),
     move(TxObj, Root, SrcPath, TgtPath).
 
-
 remove(TxObj, Node) ->
     remove_int(TxObj, Node, {}, false).
-
 
 remove(TxObj, Node, Path) ->
     remove_int(TxObj, Node, Path, false).
 
-
 remove_if_exists(TxObj, Node) ->
     remove_int(TxObj, Node, {}, true).
-
 
 remove_if_exists(TxObj, Node, Path) ->
     remove_int(TxObj, Node, Path, true).
 
-
 get_id(Node) ->
     invoke(Node, get_id, []).
-
 
 get_name(Node) ->
     invoke(Node, get_name, []).
 
-
 get_root(Node) ->
     invoke(Node, get_root, []).
-
 
 get_root_for_path(Node, Path) ->
     invoke(Node, get_root_for_path, [Path]).
 
-
 get_partition(Node) ->
     invoke(Node, get_partition, []).
-
 
 get_node_prefix(Node) ->
     invoke(Node, get_node_prefix, []).
 
-
 get_path(Node) ->
     invoke(Node, get_path, []).
-
 
 get_layer(Node) ->
     invoke(Node, get_layer, []).
 
-
 get_subspace(Node) ->
     invoke(Node, get_subspace, []).
-
 
 subspace(Node, Tuple) ->
     erlfdb_subspace:create(get_subspace(Node), Tuple).
 
-
 key(Node) ->
     erlfdb_subspace:key(get_subspace(Node)).
-
 
 pack(Node, Tuple) ->
     erlfdb_subspace:pack(get_subspace(Node), Tuple).
 
-
 pack_vs(Node, Tuple) ->
     erlfdb_subspace:pack_vs(get_subspace(Node), Tuple).
-
 
 unpack(Node, Key) ->
     erlfdb_subspace:unpack(get_subspace(Node), Key).
 
-
 range(Node) ->
     range(Node, {}).
-
 
 range(Node, Tuple) ->
     erlfdb_subspace:range(get_subspace(Node), Tuple).
 
-
 contains(Node, Key) ->
     erlfdb_subspace:contains(get_subspace(Node), Key).
 
-
 debug_nodes(TxObj, _Node) ->
-    erlfdb:fold_range(TxObj, <<16#02>>, <<16#FF>>, fun({K, V}, _Acc) ->
-        io:format(standard_error, "~s => ~s~n", [
+    erlfdb:fold_range(
+        TxObj,
+        <<16#02>>,
+        <<16#FF>>,
+        fun({K, V}, _Acc) ->
+            io:format(standard_error, "~s => ~s~n", [
                 erlfdb_util:repr(K),
                 erlfdb_util:repr(V)
             ])
-    end, nil).
-
+        end,
+        nil
+    ).
 
 invoke(not_found, _, _) ->
     erlang:error(broken);
-
 invoke(Node, FunName, Args) ->
     case Node of
         #{FunName := Fun} ->
@@ -320,7 +293,6 @@ invoke(Node, FunName, Args) ->
         #{} ->
             ?ERLFDB_ERROR({op_not_supported, FunName, Node})
     end.
-
 
 init_root(Options) ->
     DefNodePref = ?DEFAULT_NODE_PREFIX,
@@ -349,23 +321,22 @@ init_root(Options) ->
         end
     }.
 
-
 init_node(Tx, Node, NodeName, PathName) ->
     NodePrefix = get_node_prefix(Node),
     NodeLayerId = ?ERLFDB_PACK(NodePrefix, {NodeName, <<"layer">>}),
-    Layer = case erlfdb:wait(erlfdb:get(Tx, NodeLayerId)) of
-        not_found ->
-            ?ERLFDB_ERROR({internal_error, missing_node_layer, NodeLayerId});
-        LName ->
-            LName
-    end,
+    Layer =
+        case erlfdb:wait(erlfdb:get(Tx, NodeLayerId)) of
+            not_found ->
+                ?ERLFDB_ERROR({internal_error, missing_node_layer, NodeLayerId});
+            LName ->
+                LName
+        end,
     case Layer of
         <<"partition">> ->
             init_partition(Node, NodeName, PathName);
         _ ->
             init_directory(Node, NodeName, PathName, Layer)
     end.
-
 
 init_partition(ParentNode, NodeName, PathName) ->
     NodeNameLen = size(NodeName),
@@ -402,7 +373,6 @@ init_partition(ParentNode, NodeName, PathName) ->
         end
     }.
 
-
 init_directory(ParentNode, NodeName, PathName, Layer) ->
     NodePrefix = get_node_prefix(ParentNode),
     ParentPath = get_path(ParentNode),
@@ -432,10 +402,8 @@ init_directory(ParentNode, NodeName, PathName, Layer) ->
         end
     }.
 
-
 find(_Tx, Node, []) ->
     Node;
-
 find(Tx, Node, [PathName | RestPath]) ->
     NodeEntryId = ?ERLFDB_PACK(get_id(Node), {?SUBDIRS, PathName}),
     case erlfdb:wait(erlfdb:get(Tx, NodeEntryId)) of
@@ -446,10 +414,8 @@ find(Tx, Node, [PathName | RestPath]) ->
             find(Tx, ChildNode, RestPath)
     end.
 
-
 find_deepest(_Tx, Node, []) ->
     Node;
-
 find_deepest(Tx, Node, [PathName | RestPath]) ->
     NodeEntryId = ?ERLFDB_PACK(get_id(Node), {?SUBDIRS, PathName}),
     case erlfdb:wait(erlfdb:get(Tx, NodeEntryId)) of
@@ -460,63 +426,69 @@ find_deepest(Tx, Node, [PathName | RestPath]) ->
             find_deepest(Tx, ChildNode, RestPath)
     end.
 
-
 create_or_open_int(_TxObj, Node, [], LayerIn) ->
-    Layer = case LayerIn of
-        <<>> -> <<>>;
-        null -> <<>>;
-        undefined -> <<>>;
-        Else when is_binary(Else) -> Else
-    end,
+    Layer =
+        case LayerIn of
+            <<>> -> <<>>;
+            null -> <<>>;
+            undefined -> <<>>;
+            Else when is_binary(Else) -> Else
+        end,
     NodeLayer = get_layer(Node),
-    if Layer == <<>> orelse Layer == NodeLayer -> ok; true ->
-        ?ERLFDB_ERROR({open_error, layer_mismatch, Layer, NodeLayer})
+    if
+        Layer == <<>> orelse Layer == NodeLayer -> ok;
+        true -> ?ERLFDB_ERROR({open_error, layer_mismatch, Layer, NodeLayer})
     end,
     Node;
-
 create_or_open_int(TxObj, Node, PathIn, Layer) ->
     {Root, Path} = adj_path(Node, PathIn),
     erlfdb:transactional(TxObj, fun(Tx) ->
         {ParentPath, [PathName]} = lists:split(length(Path) - 1, Path),
 
-        Parent = lists:foldl(fun(Name, CurrNode) ->
-            try
-                open_int(Tx, CurrNode, Name, <<>>)
-            catch error:{?MODULE, {open_error, path_missing, _}} ->
-                create_int(Tx, CurrNode, Name, <<>>, undefined)
-            end
-        end, Root, ParentPath),
+        Parent = lists:foldl(
+            fun(Name, CurrNode) ->
+                try
+                    open_int(Tx, CurrNode, Name, <<>>)
+                catch
+                    error:{?MODULE, {open_error, path_missing, _}} ->
+                        create_int(Tx, CurrNode, Name, <<>>, undefined)
+                end
+            end,
+            Root,
+            ParentPath
+        ),
 
         try
             open_int(Tx, Parent, PathName, Layer)
-        catch error:{?MODULE, {open_error, path_missing, _}} ->
-            create_int(Tx, Parent, PathName, Layer, undefined)
+        catch
+            error:{?MODULE, {open_error, path_missing, _}} ->
+                create_int(Tx, Parent, PathName, Layer, undefined)
         end
     end).
-
 
 create_int(Tx, Node, PathIn, Layer, NodeNameIn) ->
     Path = path_init(PathIn),
     try
         open_int(Tx, Node, Path, <<>>),
         ?ERLFDB_ERROR({create_error, path_exists, Path})
-    catch error:{?MODULE, {open_error, path_missing, _}} ->
-        Deepest = find_deepest(Tx, Node, Path),
-        NodeName = create_node_name(Tx, Deepest, NodeNameIn),
-        {ParentPath, [PathName]} = lists:split(length(Path) - 1, Path),
-        case create_or_open_int(Tx, Node, ParentPath, <<>>) of
-            not_found ->
-                ?ERLFDB_ERROR({create_error, missing_parent, ParentPath});
-            Parent ->
-                check_version(Tx, Parent, write),
-                create_node(Tx, Parent, PathName, NodeName, Layer),
-                R = find(Tx, Parent, [PathName]),
-                if R /= not_found -> R; true ->
-                    erlang:error(broken)
-                end
-        end
+    catch
+        error:{?MODULE, {open_error, path_missing, _}} ->
+            Deepest = find_deepest(Tx, Node, Path),
+            NodeName = create_node_name(Tx, Deepest, NodeNameIn),
+            {ParentPath, [PathName]} = lists:split(length(Path) - 1, Path),
+            case create_or_open_int(Tx, Node, ParentPath, <<>>) of
+                not_found ->
+                    ?ERLFDB_ERROR({create_error, missing_parent, ParentPath});
+                Parent ->
+                    check_version(Tx, Parent, write),
+                    create_node(Tx, Parent, PathName, NodeName, Layer),
+                    R = find(Tx, Parent, [PathName]),
+                    if
+                        R /= not_found -> R;
+                        true -> erlang:error(broken)
+                    end
+            end
     end.
-
 
 create_node(Tx, Parent, PathName, NodeName, LayerIn) ->
     NodeEntryId = ?ERLFDB_PACK(get_id(Parent), {?SUBDIRS, PathName}),
@@ -524,9 +496,12 @@ create_node(Tx, Parent, PathName, NodeName, LayerIn) ->
 
     NodePrefix = get_node_prefix(Parent),
     NodeLayerId = ?ERLFDB_PACK(NodePrefix, {NodeName, <<"layer">>}),
-    Layer = if LayerIn == undefined -> <<>>; true -> LayerIn end,
+    Layer =
+        if
+            LayerIn == undefined -> <<>>;
+            true -> LayerIn
+        end,
     erlfdb:set(Tx, NodeLayerId, Layer).
-
 
 open_int(Tx, Node, PathIn, Layer) ->
     check_version(Tx, Node, read),
@@ -538,12 +513,12 @@ open_int(Tx, Node, PathIn, Layer) ->
             ?ERLFDB_ERROR({open_error, cannot_open_root});
         Opened ->
             NodeLayer = get_layer(Opened),
-            if Layer == <<>> orelse Layer == NodeLayer -> ok; true ->
-                ?ERLFDB_ERROR({open_error, layer_mismatch, Layer, NodeLayer})
+            if
+                Layer == <<>> orelse Layer == NodeLayer -> ok;
+                true -> ?ERLFDB_ERROR({open_error, layer_mismatch, Layer, NodeLayer})
             end,
             Opened
     end.
-
 
 remove_int(TxObj, Node, PathIn, IgnoreMissing) ->
     Root = get_root_for_path(Node, PathIn),
@@ -563,12 +538,14 @@ remove_int(TxObj, Node, PathIn, IgnoreMissing) ->
         end
     end).
 
-
 remove_recursive(Tx, Node) ->
     % Remove all subdirectories
-    lists:foreach(fun({_DirName, ChildNode}) ->
-        remove_recursive(Tx, ChildNode)
-    end, list(Tx, Node)),
+    lists:foreach(
+        fun({_DirName, ChildNode}) ->
+            remove_recursive(Tx, ChildNode)
+        end,
+        list(Tx, Node)
+    ),
 
     % Delete all content for the node.
     ContentSS = erlfdb_subspace:create({}, get_name(Node)),
@@ -580,7 +557,6 @@ remove_recursive(Tx, Node) ->
     {NodeStart, NodeEnd} = erlfdb_subspace:range(NodeSubspace),
     erlfdb:clear_range(Tx, NodeStart, NodeEnd).
 
-
 remove_from_parent(Tx, Node) ->
     {Root, Path} = adj_path(get_root_for_path(Node, []), Node, []),
     {ParentPath, [PathName]} = lists:split(length(Path) - 1, Path),
@@ -589,14 +565,13 @@ remove_from_parent(Tx, Node) ->
     NodeEntryId = ?ERLFDB_PACK(get_id(Parent), {?SUBDIRS, PathName}),
     erlfdb:clear(Tx, NodeEntryId).
 
-
 check_manual_node_name(Root, Options) ->
     AllowManual = maps:get(allow_manual_names, Root),
     IsManual = lists:keyfind(node_name, 1, Options) /= false,
-    if not (IsManual and not AllowManual) -> ok; true ->
-        ?ERLFDB_ERROR({create_error, manual_node_names_prohibited})
+    if
+        not (IsManual and not AllowManual) -> ok;
+        true -> ?ERLFDB_ERROR({create_error, manual_node_names_prohibited})
     end.
-
 
 create_node_name(Tx, Parent, NameIn) ->
     #{
@@ -604,11 +579,12 @@ create_node_name(Tx, Parent, NameIn) ->
         allow_manual_names := AllowManual,
         allocator := Allocator
     } = get_root(Parent),
-    Name = case NameIn of
-        null -> undefined;
-        undefined -> undefined;
-        _ when is_binary(NameIn) -> NameIn
-    end,
+    Name =
+        case NameIn of
+            null -> undefined;
+            undefined -> undefined;
+            _ when is_binary(NameIn) -> NameIn
+        end,
     case Name of
         _ when Name == undefined ->
             BaseId = erlfdb_hca:allocate(Allocator, Tx),
@@ -616,8 +592,11 @@ create_node_name(Tx, Parent, NameIn) ->
             NewName = <<ContentPrefix:CPLen/binary, BaseId/binary>>,
 
             KeysExist = erlfdb:get_range_startswith(Tx, NewName, [{limit, 1}]),
-            if KeysExist == [] -> ok; true ->
-                ?ERLFDB_ERROR({
+            if
+                KeysExist == [] ->
+                    ok;
+                true ->
+                    ?ERLFDB_ERROR({
                         create_error,
                         keys_exist_for_allocated_name,
                         NewName
@@ -625,8 +604,11 @@ create_node_name(Tx, Parent, NameIn) ->
             end,
 
             IsFree = is_prefix_free(erlfdb:snapshot(Tx), Parent, NewName),
-            if IsFree -> ok; true ->
-                ?ERLFDB_ERROR({
+            if
+                IsFree ->
+                    ok;
+                true ->
+                    ?ERLFDB_ERROR({
                         create_error,
                         manual_names_conflict_with_allocated_name,
                         NewName
@@ -646,7 +628,6 @@ create_node_name(Tx, Parent, NameIn) ->
             ?ERLFDB_ERROR({create_error, manual_node_names_prohibited})
     end.
 
-
 is_prefix_free(Tx, Parent, NodeName) ->
     % We have to make sure that NodeName does not interact with
     % anything that currently exists in the tree. This means that
@@ -661,8 +642,9 @@ is_prefix_free(Tx, Parent, NodeName) ->
 
     try
         % An empty name would obviously be kind of bonkers.
-        if NodeName /= <<>> -> ok; true ->
-            throw(false)
+        if
+            NodeName /= <<>> -> ok;
+            true -> throw(false)
         end,
 
         Root = get_root(Parent),
@@ -681,13 +663,20 @@ is_prefix_free(Tx, Parent, NodeName) ->
         End1 = ?ERLFDB_PACK(NodePrefix, {NodeName, null}),
         Opts1 = [{reverse, true}, {limit, 1}, {streaming_mode, exact}],
         Subspace = erlfdb_subspace:create({}, get_node_prefix(Parent)),
-        erlfdb:fold_range(Tx, Start1, End1, fun({Key, _} = _E, _) ->
-            KeyNodeId = element(1, erlfdb_subspace:unpack(Subspace, Key)),
-            case bin_startswith(NodeName, KeyNodeId) of
-                true -> throw(false);
-                false -> ok
-            end
-        end, nil, Opts1),
+        erlfdb:fold_range(
+            Tx,
+            Start1,
+            End1,
+            fun({Key, _} = _E, _) ->
+                KeyNodeId = element(1, erlfdb_subspace:unpack(Subspace, Key)),
+                case bin_startswith(NodeName, KeyNodeId) of
+                    true -> throw(false);
+                    false -> ok
+                end
+            end,
+            nil,
+            Opts1
+        ),
 
         % Check if NodeName is a prefix of any existing key
         Start2 = ?ERLFDB_EXTEND(NodePrefix, NodeName),
@@ -699,10 +688,10 @@ is_prefix_free(Tx, Parent, NodeName) ->
         end,
 
         true
-    catch throw:false ->
-        false
+    catch
+        throw:false ->
+            false
     end.
-
 
 bin_startswith(Subject, Prefix) ->
     PrefixLen = size(Prefix),
@@ -711,58 +700,57 @@ bin_startswith(Subject, Prefix) ->
         _ -> false
     end.
 
-
 check_version(Tx, Node, PermLevel) ->
     Root = get_root(Node),
     VsnKey = ?ERLFDB_EXTEND(get_id(Root), <<"version">>),
     {LV1, LV2, _LV3} = ?LAYER_VERSION,
-    {Major, Minor, Patch} = case erlfdb:wait(erlfdb:get(Tx, VsnKey)) of
-        not_found when PermLevel == write ->
-            initialize_directory(Tx, VsnKey);
-        not_found ->
-            ?LAYER_VERSION;
-        VsnBin ->
-            <<
-                V1:32/little-unsigned,
-                V2:32/little-unsigned,
-                V3:32/little-unsigned
-            >> = VsnBin,
-            {V1, V2, V3}
-    end,
+    {Major, Minor, Patch} =
+        case erlfdb:wait(erlfdb:get(Tx, VsnKey)) of
+            not_found when PermLevel == write ->
+                initialize_directory(Tx, VsnKey);
+            not_found ->
+                ?LAYER_VERSION;
+            VsnBin ->
+                <<
+                    V1:32/little-unsigned,
+                    V2:32/little-unsigned,
+                    V3:32/little-unsigned
+                >> = VsnBin,
+                {V1, V2, V3}
+        end,
 
     Path = get_path(Node),
 
-    if Major =< LV1 -> ok; true ->
-        ?ERLFDB_ERROR({version_error, unreadable, Path, {Major, Minor, Patch}})
+    if
+        Major =< LV1 -> ok;
+        true -> ?ERLFDB_ERROR({version_error, unreadable, Path, {Major, Minor, Patch}})
     end,
 
-    if not (Minor > LV2 andalso PermLevel /= read) -> ok; true ->
-        ?ERLFDB_ERROR({version_error, unwritable, Path, {Major, Minor, Patch}})
+    if
+        not (Minor > LV2 andalso PermLevel /= read) -> ok;
+        true -> ?ERLFDB_ERROR({version_error, unwritable, Path, {Major, Minor, Patch}})
     end.
-
 
 initialize_directory(Tx, VsnKey) ->
     {V1, V2, V3} = ?LAYER_VERSION,
     Packed = <<
-            V1:32/little-unsigned,
-            V2:32/little-unsigned,
-            V3:32/little-unsigned
-        >>,
+        V1:32/little-unsigned,
+        V2:32/little-unsigned,
+        V3:32/little-unsigned
+    >>,
     erlfdb:set(Tx, VsnKey, Packed),
     ?LAYER_VERSION.
-
 
 check_same_partition(OldNode, NewParentNode) ->
     OldRoot = get_partition(OldNode),
     NewRoot = get_root(NewParentNode),
-    if NewRoot == OldRoot -> ok; true ->
-        ?ERLFDB_ERROR({move_error, partition_mismatch, OldRoot, NewRoot})
+    if
+        NewRoot == OldRoot -> ok;
+        true -> ?ERLFDB_ERROR({move_error, partition_mismatch, OldRoot, NewRoot})
     end.
-
 
 adj_path(Node, PathIn) ->
     adj_path(get_root(Node), Node, PathIn).
-
 
 adj_path(Root, Node, PathIn) ->
     RootPathLen = length(get_path(Root)),
@@ -771,26 +759,23 @@ adj_path(Root, Node, PathIn) ->
     Path = NodeRelPath ++ path_init(PathIn),
     {Root, Path}.
 
-
 path_init(<<_/binary>> = Bin) ->
     check_utf8(0, Bin),
     [{utf8, Bin}];
-
 path_init({utf8, <<_/binary>> = Bin} = Path) ->
     check_utf8(0, Bin),
     [Path];
-
 path_init(Path) when is_list(Path) ->
-    lists:flatmap(fun(Part) ->
-        path_init(Part)
-    end, Path);
-
+    lists:flatmap(
+        fun(Part) ->
+            path_init(Part)
+        end,
+        Path
+    );
 path_init(Path) when is_tuple(Path) ->
     path_init(tuple_to_list(Path));
-
 path_init(Else) ->
     ?ERLFDB_ERROR({path_error, invalid_path_component, Else}).
-
 
 check_utf8(Offset, Binary) ->
     case Binary of
@@ -806,20 +791,18 @@ check_utf8(Offset, Binary) ->
             ?ERLFDB_ERROR({path_error, invalid_utf8, Binary})
     end.
 
-
 path_append(Path, Part) ->
     Path ++ path_init(Part).
-
 
 check_not_subpath(OldPath, NewPath) ->
     case lists:prefix(OldPath, NewPath) of
         true ->
             ?ERLFDB_ERROR({
-                    move_error,
-                    target_is_subdirectory,
-                    OldPath,
-                    NewPath
-                });
+                move_error,
+                target_is_subdirectory,
+                OldPath,
+                NewPath
+            });
         false ->
             ok
     end.

--- a/src/erlfdb_float.erl
+++ b/src/erlfdb_float.erl
@@ -17,8 +17,6 @@
     encode/1
 ]).
 
-
-
 decode(<<_Sign:1, 0:8, _Fraction:23>> = F) ->
     {float, denormalized, F};
 decode(<<_Sign:1, 255:8, 0:23>> = F) ->
@@ -27,7 +25,6 @@ decode(<<_Sign:1, 255:8, _Fraction:23>> = F) ->
     {float, nan, F};
 decode(<<F:32/float>>) ->
     {float, F};
-
 decode(<<_Sign:1, 0:11, _Fraction:52>> = D) ->
     {double, denormalized, D};
 decode(<<_Sign:1, 2047:11, 0:52>> = D) ->
@@ -37,9 +34,7 @@ decode(<<_Sign:1, 2047:11, _Fraction:52>> = D) ->
 decode(<<D:64/float>>) ->
     D.
 
-
 encode({float, F}) -> <<F:32/float>>;
 encode({float, _Type, F}) -> F;
-
 encode(F) when is_float(F) -> <<F:64/float>>;
 encode({double, _Type, D}) -> D.

--- a/src/erlfdb_key.erl
+++ b/src/erlfdb_key.erl
@@ -12,7 +12,6 @@
 
 -module(erlfdb_key).
 
-
 -export([
     to_selector/1,
 
@@ -24,7 +23,6 @@
     strinc/1
 ]).
 
-
 to_selector(<<_/binary>> = Key) ->
     {Key, gteq};
 to_selector({<<_/binary>>, _} = Sel) ->
@@ -34,22 +32,17 @@ to_selector({<<_/binary>>, _, _} = Sel) ->
 to_selector(Else) ->
     erlang:error({invalid_key_selector, Else}).
 
-
 last_less_than(Key) when is_binary(Key) ->
     {Key, lt}.
-
 
 last_less_or_equal(Key) when is_binary(Key) ->
     {Key, lteq}.
 
-
 first_greater_than(Key) when is_binary(Key) ->
     {Key, gt}.
 
-
 first_greater_or_equal(Key) when is_binary(Key) ->
     {Key, gteq}.
-
 
 strinc(Key) when is_binary(Key) ->
     Prefix = rstrip_ff(Key),
@@ -58,10 +51,8 @@ strinc(Key) when is_binary(Key) ->
     Tail = binary:at(Prefix, PrefixLen - 1),
     <<Head/binary, (Tail + 1)>>.
 
-
 rstrip_ff(<<>>) ->
     erlang:error("Key must contain at least one byte not equal to 0xFF");
-
 rstrip_ff(Key) ->
     KeyLen = size(Key),
     case binary:at(Key, KeyLen - 1) of

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -61,11 +61,9 @@
     error_predicate/2
 ]).
 
-
 -define(DEFAULT_API_VERSION, 620).
 
-
--type error() :: {erlfdb_error, Code::integer()}.
+-type error() :: {erlfdb_error, Code :: integer()}.
 -type future() :: {erlfdb_future, reference(), reference()}.
 -type database() :: {erlfdb_database, reference()}.
 -type transaction() :: {erlfdb_transaction, reference()}.
@@ -73,245 +71,236 @@
 -type option_value() :: integer() | binary().
 
 -type key_selector() ::
-    {Key::binary(), lt | lteq | gt | gteq} |
-    {Key::binary(), OrEqual::boolean(), Offset::integer()}.
+    {Key :: binary(), lt | lteq | gt | gteq}
+    | {Key :: binary(), OrEqual :: boolean(), Offset :: integer()}.
 
 -type future_result() ::
-    database() |
-    integer() |
-    binary() |
-    {[{binary(), binary()}], integer(), boolean()} |
-    not_found |
-    {error, invalid_future_type}.
+    database()
+    | integer()
+    | binary()
+    | {[{binary(), binary()}], integer(), boolean()}
+    | not_found
+    | {error, invalid_future_type}.
 
 -type network_option() ::
-    local_address |
-    cluster_file |
-    trace_enable |
-    trace_format |
-    trace_roll_size |
-    trace_max_logs_size |
-    trace_log_group |
-    knob |
-    tls_plugin |
-    tls_cert_bytes |
-    tls_cert_path |
-    tls_key_bytes |
-    tls_key_path |
-    tls_verify_peers |
-    client_buggify_enable |
-    client_buggify_disable |
-    client_buggify_section_activated_probability |
-    client_buggify_section_fired_probability |
-    tls_ca_bytes |
-    tls_ca_path |
-    tls_password |
-    disable_multi_version_client_api |
-    callbacks_on_external_threads |
-    external_client_library |
-    external_client_directory |
-    disable_local_client |
-    disable_client_statistics_logging |
-    enable_slow_task_profiling.
+    local_address
+    | cluster_file
+    | trace_enable
+    | trace_format
+    | trace_roll_size
+    | trace_max_logs_size
+    | trace_log_group
+    | knob
+    | tls_plugin
+    | tls_cert_bytes
+    | tls_cert_path
+    | tls_key_bytes
+    | tls_key_path
+    | tls_verify_peers
+    | client_buggify_enable
+    | client_buggify_disable
+    | client_buggify_section_activated_probability
+    | client_buggify_section_fired_probability
+    | tls_ca_bytes
+    | tls_ca_path
+    | tls_password
+    | disable_multi_version_client_api
+    | callbacks_on_external_threads
+    | external_client_library
+    | external_client_directory
+    | disable_local_client
+    | disable_client_statistics_logging
+    | enable_slow_task_profiling.
 
 -type database_option() ::
-    location_cache_size |
-    max_watches |
-    machine_id |
-    datacenter_id.
+    location_cache_size
+    | max_watches
+    | machine_id
+    | datacenter_id.
 
 -type transaction_option() ::
-    causal_write_risky |
-    causal_read_risky |
-    causal_read_disable |
-    next_write_no_write_conflict_range |
-    read_your_writes_disable |
-    read_ahead_disable |
-    durability_datacenter |
-    durability_risky |
-    durability_dev_null_is_web_scale |
-    priority_system_immediate |
-    priority_batch |
-    initialize_new_database |
-    access_system_keys |
-    read_system_keys |
-    debug_retry_logging |
-    transaction_logging_enable |
-    timeout |
-    retry_limit |
-    max_retry_delay |
-    snapshot_ryw_enable |
-    snapshot_ryw_disable |
-    lock_aware |
-    used_during_commit_protection_disable |
-    read_lock_aware |
-    size_limit |
-    allow_writes |
-    disallow_writes.
-
+    causal_write_risky
+    | causal_read_risky
+    | causal_read_disable
+    | next_write_no_write_conflict_range
+    | read_your_writes_disable
+    | read_ahead_disable
+    | durability_datacenter
+    | durability_risky
+    | durability_dev_null_is_web_scale
+    | priority_system_immediate
+    | priority_batch
+    | initialize_new_database
+    | access_system_keys
+    | read_system_keys
+    | debug_retry_logging
+    | transaction_logging_enable
+    | timeout
+    | retry_limit
+    | max_retry_delay
+    | snapshot_ryw_enable
+    | snapshot_ryw_disable
+    | lock_aware
+    | used_during_commit_protection_disable
+    | read_lock_aware
+    | size_limit
+    | allow_writes
+    | disallow_writes.
 
 -type streaming_mode() ::
-    stream_want_all |
-    stream_iterator |
-    stream_exact |
-    stream_small |
-    stream_medium |
-    stream_large |
-    stream_serial.
+    stream_want_all
+    | stream_iterator
+    | stream_exact
+    | stream_small
+    | stream_medium
+    | stream_large
+    | stream_serial.
 
 -type atomic_mode() ::
-    add |
-    bit_and |
-    bit_or |
-    bit_xor |
-    append_if_fits |
-    max |
-    min |
-    byte_min |
-    byte_max |
-    set_versionstamped_key |
-    set_versionstamped_value.
+    add
+    | bit_and
+    | bit_or
+    | bit_xor
+    | append_if_fits
+    | max
+    | min
+    | byte_min
+    | byte_max
+    | set_versionstamped_key
+    | set_versionstamped_value.
 
 -type atomic_operand() :: integer() | binary().
 
 -type conflict_type() :: read | write.
 
 -type error_predicate() ::
-        retryable |
-        maybe_committed |
-        retryable_not_committed.
-
+    retryable
+    | maybe_committed
+    | retryable_not_committed.
 
 ohai() ->
     foo.
-
 
 -spec get_max_api_version() -> {ok, integer()}.
 get_max_api_version() ->
     erlfdb_get_max_api_version().
 
-
 -spec future_cancel(future()) -> ok.
 future_cancel({erlfdb_future, _Ref, Ft}) ->
     erlfdb_future_cancel(Ft).
-
 
 -spec future_silence(future()) -> ok.
 future_silence({erlfdb_future, _Ref, Ft}) ->
     erlfdb_future_silence(Ft).
 
-
 -spec future_is_ready(future()) -> boolean().
 future_is_ready({erlfdb_future, _Ref, Ft}) ->
     erlfdb_future_is_ready(Ft).
-
 
 -spec future_get_error(future()) -> error().
 future_get_error({erlfdb_future, _Ref, Ft}) ->
     erlfdb_future_get_error(Ft).
 
-
 -spec future_get(future()) -> future_result().
 future_get({erlfdb_future, _Ref, Ft}) ->
     erlfdb_future_get(Ft).
 
-
--spec create_database(ClusterFilePath::binary()) -> database().
+-spec create_database(ClusterFilePath :: binary()) -> database().
 create_database(<<>>) ->
     create_database(<<0>>);
-
 create_database(ClusterFilePath) ->
     Size = size(ClusterFilePath) - 1,
     % Make sure we pass a NULL-terminated string
     % to FoundationDB
-    NifPath = case ClusterFilePath of
-        <<_:Size/binary, 0>> ->
-            ClusterFilePath;
-        _ ->
-            <<ClusterFilePath/binary, 0>>
-    end,
+    NifPath =
+        case ClusterFilePath of
+            <<_:Size/binary, 0>> ->
+                ClusterFilePath;
+            _ ->
+                <<ClusterFilePath/binary, 0>>
+        end,
     erlfdb_create_database(NifPath).
 
-
--spec database_set_option(database(), Option::database_option()) -> ok.
+-spec database_set_option(database(), Option :: database_option()) -> ok.
 database_set_option(Database, Option) ->
     database_set_option(Database, Option, <<>>).
 
-
 -spec database_set_option(
-        database(),
-        Option::database_option(),
-        Value::option_value()
-    ) -> ok.
+    database(),
+    Option :: database_option(),
+    Value :: option_value()
+) -> ok.
 database_set_option({erlfdb_database, Db}, Opt, Val) ->
     BinVal = option_val_to_binary(Val),
     erlfdb_database_set_option(Db, Opt, BinVal).
-
 
 -spec database_create_transaction(database()) -> transaction().
 database_create_transaction({erlfdb_database, Db}) ->
     erlfdb_database_create_transaction(Db).
 
-
--spec transaction_set_option(transaction(), Option::transaction_option()) -> ok.
+-spec transaction_set_option(transaction(), Option :: transaction_option()) -> ok.
 transaction_set_option(Transaction, Option) ->
     transaction_set_option(Transaction, Option, <<>>).
 
-
 -spec transaction_set_option(
-        transaction(),
-        Option::transaction_option(),
-        Value::option_value()
-    ) -> ok.
+    transaction(),
+    Option :: transaction_option(),
+    Value :: option_value()
+) -> ok.
 transaction_set_option({erlfdb_transaction, Tx}, Opt, Val) ->
     BinVal = option_val_to_binary(Val),
     erlfdb_transaction_set_option(Tx, Opt, BinVal).
 
-
--spec transaction_set_read_version(transaction(), Version::integer()) -> ok.
+-spec transaction_set_read_version(transaction(), Version :: integer()) -> ok.
 transaction_set_read_version({erlfdb_transaction, Tx}, Version) ->
     erlfdb_transaction_set_read_version(Tx, Version).
-
 
 -spec transaction_get_read_version(transaction()) -> future().
 transaction_get_read_version({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_read_version(Tx).
 
-
--spec transaction_get(transaction(), Key::binary(), Snapshot::boolean()) ->
-        future().
+-spec transaction_get(transaction(), Key :: binary(), Snapshot :: boolean()) ->
+    future().
 transaction_get({erlfdb_transaction, Tx}, Key, Snapshot) ->
     erlfdb_transaction_get(Tx, Key, Snapshot).
 
-
 -spec transaction_get_key(
-        transaction(),
-        KeySelector::key_selector(),
-        Snapshot::boolean()
-    ) -> future().
+    transaction(),
+    KeySelector :: key_selector(),
+    Snapshot :: boolean()
+) -> future().
 transaction_get_key({erlfdb_transaction, Tx}, KeySelector, Snapshot) ->
     erlfdb_transaction_get_key(Tx, KeySelector, Snapshot).
 
-
--spec transaction_get_addresses_for_key(transaction(), Key::binary()) ->
-        future().
+-spec transaction_get_addresses_for_key(transaction(), Key :: binary()) ->
+    future().
 transaction_get_addresses_for_key({erlfdb_transaction, Tx}, Key) ->
     erlfdb_transaction_get_addresses_for_key(Tx, Key).
 
-
 -spec transaction_get_range(
-        transaction(),
-        StartKeySelector::key_selector(),
-        EndKeySelector::key_selector(),
-        Limit::non_neg_integer(),
-        TargetBytes::non_neg_integer(),
-        StreamingMode::streaming_mode(),
-        Iteration::non_neg_integer(),
-        Snapshot::boolean(),
-        Reverse::integer()
-    ) -> future().
+    transaction(),
+    StartKeySelector :: key_selector(),
+    EndKeySelector :: key_selector(),
+    Limit :: non_neg_integer(),
+    TargetBytes :: non_neg_integer(),
+    StreamingMode :: streaming_mode(),
+    Iteration :: non_neg_integer(),
+    Snapshot :: boolean(),
+    Reverse :: integer()
+) -> future().
 transaction_get_range(
-        {erlfdb_transaction, Tx},
+    {erlfdb_transaction, Tx},
+    StartKeySelector,
+    EndKeySelector,
+    Limit,
+    TargetBytes,
+    StreamingMode,
+    Iteration,
+    Snapshot,
+    Reverse
+) ->
+    erlfdb_transaction_get_range(
+        Tx,
         StartKeySelector,
         EndKeySelector,
         Limit,
@@ -320,207 +309,180 @@ transaction_get_range(
         Iteration,
         Snapshot,
         Reverse
-    ) ->
-    erlfdb_transaction_get_range(
-            Tx,
-            StartKeySelector,
-            EndKeySelector,
-            Limit,
-            TargetBytes,
-            StreamingMode,
-            Iteration,
-            Snapshot,
-            Reverse
-        ).
+    ).
 
-
--spec transaction_set(transaction(), Key::binary(), Val::binary()) -> ok.
+-spec transaction_set(transaction(), Key :: binary(), Val :: binary()) -> ok.
 transaction_set({erlfdb_transaction, Tx}, Key, Val) ->
     erlfdb_transaction_set(Tx, Key, Val).
 
-
--spec transaction_clear(transaction(), Key::binary()) -> ok.
+-spec transaction_clear(transaction(), Key :: binary()) -> ok.
 transaction_clear({erlfdb_transaction, Tx}, Key) ->
     erlfdb_transaction_clear(Tx, Key).
 
-
 -spec transaction_clear_range(
-        transaction(),
-        StartKey::binary(),
-        EndKey::binary()
-    ) -> ok.
+    transaction(),
+    StartKey :: binary(),
+    EndKey :: binary()
+) -> ok.
 transaction_clear_range({erlfdb_transaction, Tx}, StartKey, EndKey) ->
     erlfdb_transaction_clear_range(Tx, StartKey, EndKey).
 
-
 -spec transaction_atomic_op(
-        transaction(),
-        Key::binary(),
-        Operand::atomic_operand(),
-        Mode::atomic_mode()
-    ) -> ok.
+    transaction(),
+    Key :: binary(),
+    Operand :: atomic_operand(),
+    Mode :: atomic_mode()
+) -> ok.
 transaction_atomic_op({erlfdb_transaction, Tx}, Key, Operand, OpName) ->
-    BinOperand = case Operand of
-        Bin when is_binary(Bin) ->
-            Bin;
-        Int when is_integer(Int) ->
-            <<Int:64/little>>
-    end,
+    BinOperand =
+        case Operand of
+            Bin when is_binary(Bin) ->
+                Bin;
+            Int when is_integer(Int) ->
+                <<Int:64/little>>
+        end,
     erlfdb_transaction_atomic_op(Tx, Key, BinOperand, OpName).
-
 
 -spec transaction_commit(transaction()) -> future().
 transaction_commit({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_commit(Tx).
 
-
 -spec transaction_get_committed_version(transaction()) -> integer().
 transaction_get_committed_version({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_committed_version(Tx).
-
 
 -spec transaction_get_versionstamp(transaction()) -> future().
 transaction_get_versionstamp({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_versionstamp(Tx).
 
-
--spec transaction_watch(transaction(), Key::binary()) -> future().
+-spec transaction_watch(transaction(), Key :: binary()) -> future().
 transaction_watch({erlfdb_transaction, Tx}, Key) ->
     erlfdb_transaction_watch(Tx, Key).
 
-
--spec transaction_on_error(transaction(), Error::integer()) -> future().
+-spec transaction_on_error(transaction(), Error :: integer()) -> future().
 transaction_on_error({erlfdb_transaction, Tx}, Error) ->
     erlfdb_transaction_on_error(Tx, Error).
-
 
 -spec transaction_reset(transaction()) -> ok.
 transaction_reset({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_reset(Tx).
 
-
 -spec transaction_cancel(transaction()) -> ok.
 transaction_cancel({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_cancel(Tx).
 
-
 -spec transaction_add_conflict_range(
-        transaction(),
-        StartKey::binary(),
-        EndKey::binary(),
-        ConflictType::conflict_type()
-    ) -> ok.
+    transaction(),
+    StartKey :: binary(),
+    EndKey :: binary(),
+    ConflictType :: conflict_type()
+) -> ok.
 transaction_add_conflict_range(
-        {erlfdb_transaction, Tx},
-        StartKey,
-        EndKey,
-        ConflictType
-    ) ->
+    {erlfdb_transaction, Tx},
+    StartKey,
+    EndKey,
+    ConflictType
+) ->
     erlfdb_transaction_add_conflict_range(Tx, StartKey, EndKey, ConflictType).
-
 
 -spec transaction_get_approximate_size(transaction()) -> non_neg_integer().
 transaction_get_approximate_size({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_approximate_size(Tx).
 
-
 -spec transaction_get_next_tx_id(transaction()) -> non_neg_integer().
 transaction_get_next_tx_id({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_next_tx_id(Tx).
-
 
 -spec transaction_is_read_only(transaction()) -> true | false.
 transaction_is_read_only({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_is_read_only(Tx).
 
-
 -spec transaction_has_watches(transaction()) -> true | false.
 transaction_has_watches({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_has_watches(Tx).
-
 
 -spec transaction_get_writes_allowed(transaction()) -> true | false.
 transaction_get_writes_allowed({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_writes_allowed(Tx).
 
-
 -spec get_error(integer()) -> binary().
 get_error(Error) ->
     erlfdb_get_error(Error).
 
-
--spec error_predicate(Predicate::error_predicate(), Error::integer()) ->
-        boolean().
+-spec error_predicate(Predicate :: error_predicate(), Error :: integer()) ->
+    boolean().
 error_predicate(Predicate, Error) ->
     erlfdb_error_predicate(Predicate, Error).
-
 
 -spec option_val_to_binary(binary() | integer()) -> binary().
 option_val_to_binary(Val) when is_binary(Val) ->
     Val;
-
 option_val_to_binary(Val) when is_integer(Val) ->
     <<Val:8/little-unsigned-integer-unit:8>>.
 
-
 init() ->
-    PrivDir = case code:priv_dir(?MODULE) of
-        {error, _} ->
-            EbinDir = filename:dirname(code:which(?MODULE)),
-            AppPath = filename:dirname(EbinDir),
-            filename:join(AppPath, "priv");
-        Path ->
-            Path
-    end,
+    PrivDir =
+        case code:priv_dir(?MODULE) of
+            {error, _} ->
+                EbinDir = filename:dirname(code:which(?MODULE)),
+                AppPath = filename:dirname(EbinDir),
+                filename:join(AppPath, "priv");
+            Path ->
+                Path
+        end,
     Status = erlang:load_nif(filename:join(PrivDir, "erlfdb_nif"), 0),
-    if Status /= ok -> Status; true ->
-        true = erlfdb_can_initialize(),
+    if
+        Status /= ok ->
+            Status;
+        true ->
+            true = erlfdb_can_initialize(),
 
-        Vsn = case application:get_env(erlfdb, api_version) of
-            {ok, V} -> V;
-            undefined -> ?DEFAULT_API_VERSION
-        end,
-        ok = select_api_version(Vsn),
+            Vsn =
+                case application:get_env(erlfdb, api_version) of
+                    {ok, V} -> V;
+                    undefined -> ?DEFAULT_API_VERSION
+                end,
+            ok = select_api_version(Vsn),
 
-        Opts = case application:get_env(erlfdb, network_options) of
-            {ok, O} when is_list(O) -> O;
-            undefined -> []
-        end,
+            Opts =
+                case application:get_env(erlfdb, network_options) of
+                    {ok, O} when is_list(O) -> O;
+                    undefined -> []
+                end,
 
-        lists:foreach(fun(Option) ->
-            case Option of
-                Name when is_atom(Name) ->
-                    ok = network_set_option(Name, <<>>);
-                {Name, Value} when is_atom(Name) ->
-                    ok = network_set_option(Name, Value)
-            end
-        end, Opts),
+            lists:foreach(
+                fun(Option) ->
+                    case Option of
+                        Name when is_atom(Name) ->
+                            ok = network_set_option(Name, <<>>);
+                        {Name, Value} when is_atom(Name) ->
+                            ok = network_set_option(Name, Value)
+                    end
+                end,
+                Opts
+            ),
 
-        ok = erlfdb_setup_network()
+            ok = erlfdb_setup_network()
     end.
-
 
 -define(NOT_LOADED, erlang:nif_error({erlfdb_nif_not_loaded, ?FILE, ?LINE})).
 
-
--spec select_api_version(Version::pos_integer()) -> ok.
+-spec select_api_version(Version :: pos_integer()) -> ok.
 select_api_version(Version) when is_integer(Version), Version > 0 ->
     erlfdb_select_api_version(Version).
 
-
--spec network_set_option(Option::network_option(), Value::option_value()) ->
-        ok | error().
+-spec network_set_option(Option :: network_option(), Value :: option_value()) ->
+    ok | error().
 network_set_option(Name, Value) ->
-    BinValue = case Value of
-        B when is_binary(B) -> B;
-        I when is_integer(I) -> <<I:8/little-unsigned-integer-unit:8>>
-    end,
+    BinValue =
+        case Value of
+            B when is_binary(B) -> B;
+            I when is_integer(I) -> <<I:8/little-unsigned-integer-unit:8>>
+        end,
     erlfdb_network_set_option(Name, BinValue).
-
 
 % Sentinel Check
 erlfdb_can_initialize() -> ?NOT_LOADED.
-
 
 % Versioning
 erlfdb_get_max_api_version() -> ?NOT_LOADED.
@@ -542,42 +504,29 @@ erlfdb_create_database(_ClusterFilePath) -> ?NOT_LOADED.
 erlfdb_database_set_option(_Database, _DatabaseOption, _Value) -> ?NOT_LOADED.
 erlfdb_database_create_transaction(_Database) -> ?NOT_LOADED.
 
-
 % Transactions
-erlfdb_transaction_set_option(
-        _Transaction,
-        _TransactionOption,
-        _Value
-    ) -> ?NOT_LOADED.
+erlfdb_transaction_set_option(_Transaction, _TransactionOption, _Value) -> ?NOT_LOADED.
 erlfdb_transaction_set_read_version(_Transaction, _Version) -> ?NOT_LOADED.
 erlfdb_transaction_get_read_version(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get(_Transaction, _Key, _Snapshot) -> ?NOT_LOADED.
-erlfdb_transaction_get_key(
-        _Transaction,
-        _KeySelector,
-        _Snapshot
-    ) -> ?NOT_LOADED.
+erlfdb_transaction_get_key(_Transaction, _KeySelector, _Snapshot) -> ?NOT_LOADED.
 erlfdb_transaction_get_addresses_for_key(_Transaction, _Key) -> ?NOT_LOADED.
 erlfdb_transaction_get_range(
-        _Transaction,
-        _StartKeySelector,
-        _EndKeySelector,
-        _Limit,
-        _TargetBytes,
-        _StreamingMode,
-        _Iteration,
-        _Snapshot,
-        _Reverse
-    ) -> ?NOT_LOADED.
+    _Transaction,
+    _StartKeySelector,
+    _EndKeySelector,
+    _Limit,
+    _TargetBytes,
+    _StreamingMode,
+    _Iteration,
+    _Snapshot,
+    _Reverse
+) ->
+    ?NOT_LOADED.
 erlfdb_transaction_set(_Transaction, _Key, _Value) -> ?NOT_LOADED.
 erlfdb_transaction_clear(_Transaction, _Key) -> ?NOT_LOADED.
 erlfdb_transaction_clear_range(_Transaction, _StartKey, _EndKey) -> ?NOT_LOADED.
-erlfdb_transaction_atomic_op(
-        _Transaction,
-        _Mutation,
-        _Key,
-        _Value
-    ) -> ?NOT_LOADED.
+erlfdb_transaction_atomic_op(_Transaction, _Mutation, _Key, _Value) -> ?NOT_LOADED.
 erlfdb_transaction_commit(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_committed_version(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_versionstamp(_Transaction) -> ?NOT_LOADED.
@@ -585,18 +534,12 @@ erlfdb_transaction_watch(_Transaction, _Key) -> ?NOT_LOADED.
 erlfdb_transaction_on_error(_Transaction, _Error) -> ?NOT_LOADED.
 erlfdb_transaction_reset(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_cancel(_Transaction) -> ?NOT_LOADED.
-erlfdb_transaction_add_conflict_range(
-        _Transaction,
-        _StartKey,
-        _EndKey,
-        _Type
-    ) -> ?NOT_LOADED.
+erlfdb_transaction_add_conflict_range(_Transaction, _StartKey, _EndKey, _Type) -> ?NOT_LOADED.
 erlfdb_transaction_get_next_tx_id(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_is_read_only(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_has_watches(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_writes_allowed(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_approximate_size(_Transaction) -> ?NOT_LOADED.
-
 
 % Misc
 erlfdb_get_error(_Error) -> ?NOT_LOADED.

--- a/src/erlfdb_subspace.erl
+++ b/src/erlfdb_subspace.erl
@@ -12,11 +12,9 @@
 
 -module(erlfdb_subspace).
 
-
 -record(erlfdb_subspace, {
     prefix
 }).
-
 
 -export([
     create/1,
@@ -40,46 +38,35 @@
     subspace/2
 ]).
 
-
 -define(PREFIX(S), S#erlfdb_subspace.prefix).
-
 
 create(Tuple) ->
     create(Tuple, <<>>).
 
-
 create(#erlfdb_subspace{} = Subspace, Tuple) when is_tuple(Tuple) ->
     create(Tuple, ?PREFIX(Subspace));
-
 create(Tuple, Prefix) when is_tuple(Tuple), is_binary(Prefix) ->
     #erlfdb_subspace{
         prefix = erlfdb_tuple:pack(Tuple, Prefix)
     }.
 
-
 add(#erlfdb_subspace{} = Subspace, Item) ->
     create({Item}, ?PREFIX(Subspace)).
-
 
 key(#erlfdb_subspace{} = Subspace) ->
     Subspace#erlfdb_subspace.prefix.
 
-
 pack(Subspace) ->
     pack(Subspace, {}).
-
 
 pack(#erlfdb_subspace{} = Subspace, Tuple) when is_tuple(Tuple) ->
     erlfdb_tuple:pack(Tuple, ?PREFIX(Subspace)).
 
-
 pack_vs(Subspace) ->
     pack_vs(Subspace, {}).
 
-
 pack_vs(#erlfdb_subspace{} = Subspace, Tuple) when is_tuple(Tuple) ->
     erlfdb_tuple:pack_vs(Tuple, ?PREFIX(Subspace)).
-
 
 unpack(#erlfdb_subspace{} = Subspace, Key) ->
     case contains(Subspace, Key) of
@@ -91,10 +78,8 @@ unpack(#erlfdb_subspace{} = Subspace, Key) ->
             erlang:error({key_not_in_subspace, Subspace, Key})
     end.
 
-
 range(Subspace) ->
     range(Subspace, {}).
-
 
 range(#erlfdb_subspace{} = Subspace, Tuple) when is_tuple(Tuple) ->
     Prefix = ?PREFIX(Subspace),
@@ -105,7 +90,6 @@ range(#erlfdb_subspace{} = Subspace, Tuple) when is_tuple(Tuple) ->
         <<Prefix:PrefixLen/binary, End/binary>>
     }.
 
-
 contains(#erlfdb_subspace{} = Subspace, Key) ->
     Prefix = ?PREFIX(Subspace),
     PrefLen = size(Prefix),
@@ -115,7 +99,6 @@ contains(#erlfdb_subspace{} = Subspace, Key) ->
         _ ->
             false
     end.
-
 
 subspace(#erlfdb_subspace{} = Subspace, Tuple) ->
     create(Subspace, Tuple).

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -12,7 +12,6 @@
 
 -module(erlfdb_util).
 
-
 -export([
     get_test_db/0,
     get_test_db/1,
@@ -28,10 +27,8 @@
     debug_cluster/3
 ]).
 
-
 get_test_db() ->
     get_test_db([]).
-
 
 get_test_db(Options) ->
     {ok, ClusterFile} = init_test_cluster(Options),
@@ -46,7 +43,6 @@ get_test_db(Options) ->
     end,
     Db.
 
-
 init_test_cluster(Options) ->
     % Hack to ensure erlfdb app environment is loaded during unit tests
     ok = application:ensure_started(erlfdb),
@@ -57,10 +53,8 @@ init_test_cluster(Options) ->
             init_test_cluster_int(Options)
     end.
 
-
 get(List, Key) ->
     get(List, Key, undefined).
-
 
 get(List, Key, Default) ->
     case lists:keyfind(Key, 1, List) of
@@ -68,40 +62,42 @@ get(List, Key, Default) ->
         _ -> Default
     end.
 
-
 repr(Bin) when is_binary(Bin) ->
-    [$'] ++ lists:map(fun(C) ->
-        case C of
-            9 -> "\\t";
-            10 -> "\\n";
-            13 -> "\\r";
-            39 -> "\\'";
-            92 -> "\\\\";
-            _ when C >= 32, C =< 126 -> C;
-            _ -> io_lib:format("\\x~2.16.0b", [C])
-        end
-    end, binary_to_list(Bin)) ++ [$'].
-
+    [$'] ++
+        lists:map(
+            fun(C) ->
+                case C of
+                    9 -> "\\t";
+                    10 -> "\\n";
+                    13 -> "\\r";
+                    39 -> "\\'";
+                    92 -> "\\\\";
+                    _ when C >= 32, C =< 126 -> C;
+                    _ -> io_lib:format("\\x~2.16.0b", [C])
+                end
+            end,
+            binary_to_list(Bin)
+        ) ++ [$'].
 
 debug_cluster(Tx) ->
     debug_cluster(Tx, <<>>, <<16#FE, 16#FF, 16#FF>>).
 
-
 debug_cluster(Tx, Start, End) ->
-    lists:foreach(fun({Key, Val}) ->
-        io:format(standard_error, "~s => ~s~n", [
+    lists:foreach(
+        fun({Key, Val}) ->
+            io:format(standard_error, "~s => ~s~n", [
                 string:pad(erlfdb_util:repr(Key), 60),
                 repr(Val)
             ])
-    end, erlfdb:get_range(Tx, Start, End)).
-
+        end,
+        erlfdb:get_range(Tx, Start, End)
+    ).
 
 init_test_cluster_int(Options) ->
     {ok, CWD} = file:get_cwd(),
     DefaultIpAddr = {127, 0, 0, 1},
     DefaultPort = get_available_port(),
     DefaultDir = filename:join(CWD, ".erlfdb"),
-
 
     IpAddr = ?MODULE:get(Options, ip_addr, DefaultIpAddr),
     Port = ?MODULE:get(Options, port, DefaultPort),
@@ -120,10 +116,14 @@ init_test_cluster_int(Options) ->
         % Open the fdbserver port
         FDBPortName = {spawn_executable, FDBServerBin},
         FDBPortArgs = [
-            <<"-p">>, ip_port_to_str(IpAddr, Port),
-            <<"-C">>, ClusterFile,
-            <<"-d">>, Dir,
-            <<"-L">>, Dir
+            <<"-p">>,
+            ip_port_to_str(IpAddr, Port),
+            <<"-C">>,
+            ClusterFile,
+            <<"-d">>,
+            Dir,
+            <<"-L">>,
+            Dir
         ],
         FDBPortOpts = [{args, FDBPortArgs}],
         FDBServer = erlang:open_port(FDBPortName, FDBPortOpts),
@@ -166,31 +166,29 @@ init_test_cluster_int(Options) ->
     ok = application:set_env(erlfdb, test_cluster_pid, FDBPid),
     {ok, ClusterFile}.
 
-
 get_available_port() ->
     {ok, Socket} = gen_tcp:listen(0, []),
     {ok, Port} = inet:port(Socket),
     ok = gen_tcp:close(Socket),
     Port.
 
-
 find_fdbserver_bin(Options) ->
-    Locations = case ?MODULE:get(Options, fdbserver_bin) of
-        undefined ->
-            [
-                <<"/usr/sbin/fdbserver">>,
-                <<"/usr/local/bin/fdbserver">>,
-                <<"/usr/local/sbin/fdbserver">>,
-                <<"/usr/local/libexec/fdbserver">>
-            ];
-        Else ->
-            [Else]
-    end,
+    Locations =
+        case ?MODULE:get(Options, fdbserver_bin) of
+            undefined ->
+                [
+                    <<"/usr/sbin/fdbserver">>,
+                    <<"/usr/local/bin/fdbserver">>,
+                    <<"/usr/local/sbin/fdbserver">>,
+                    <<"/usr/local/libexec/fdbserver">>
+                ];
+            Else ->
+                [Else]
+        end,
     case lists:filter(fun filelib:is_file/1, Locations) of
         [Path | _] -> Path;
         [] -> erlang:error(fdbserver_bin_not_found)
     end.
-
 
 write_cluster_file(FileName, ClusterName, ClusterId, IpAddr, Port) ->
     Args = [ClusterName, ClusterId, ip_port_to_str(IpAddr, Port)],
@@ -198,26 +196,26 @@ write_cluster_file(FileName, ClusterName, ClusterId, IpAddr, Port) ->
     ok = filelib:ensure_dir(FileName),
     ok = file:write_file(FileName, iolist_to_binary(Contents)).
 
-
 get_monitor_path() ->
-    PrivDir = case code:priv_dir(erlfdb) of
-        {error, _} ->
-            EbinDir = filename:dirname(code:which(?MODULE)),
-            AppPath = filename:dirname(EbinDir),
-            filename:join(AppPath, "priv");
-        Path ->
-            Path
-    end,
+    PrivDir =
+        case code:priv_dir(erlfdb) of
+            {error, _} ->
+                EbinDir = filename:dirname(code:which(?MODULE)),
+                AppPath = filename:dirname(EbinDir),
+                filename:join(AppPath, "priv");
+            Path ->
+                Path
+        end,
     filename:join(PrivDir, "monitor.py").
-
 
 init_fdb_db(ClusterFile, Options) ->
     DefaultFDBCli = os:find_executable("fdbcli"),
-    FDBCli = case ?MODULE:get(Options, fdbcli_bin, DefaultFDBCli) of
-        false -> erlang:error(fdbcli_not_found);
-        DefaultFDBCli -> "fdbcli";
-        FDBCli0 -> FDBCli0
-    end,
+    FDBCli =
+        case ?MODULE:get(Options, fdbcli_bin, DefaultFDBCli) of
+            false -> erlang:error(fdbcli_not_found);
+            DefaultFDBCli -> "fdbcli";
+            FDBCli0 -> FDBCli0
+        end,
     Fmt = "~s -C ~s --exec \"configure new single ssd\"",
     Cmd = lists:flatten(io_lib:format(Fmt, [FDBCli, ClusterFile])),
     case os:cmd(Cmd) of
@@ -225,7 +223,6 @@ init_fdb_db(ClusterFile, Options) ->
         "ERROR: Database already exists!" ++ _ -> ok;
         Msg -> erlang:error({fdb_init_error, Msg})
     end.
-
 
 port_loop(FDBServer, Monitor) ->
     receive
@@ -241,8 +238,6 @@ port_loop(FDBServer, Monitor) ->
             erlang:exit({fdb_cluster_error, Error})
     end.
 
-
 ip_port_to_str({I1, I2, I3, I4}, Port) ->
     Fmt = "~b.~b.~b.~b:~b",
     iolist_to_binary(io_lib:format(Fmt, [I1, I2, I3, I4, Port])).
-

--- a/test/erlfdb_01_basic_test.erl
+++ b/test/erlfdb_01_basic_test.erl
@@ -14,13 +14,13 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 load_test() ->
     erlfdb_nif:ohai().
 
-
 get_error_string_test() ->
     ?assertEqual(<<"Success">>, erlfdb_nif:get_error(0)),
-    ?assertEqual(<<"Transaction exceeds byte limit">>,
-        erlfdb_nif:get_error(2101)),
+    ?assertEqual(
+        <<"Transaction exceeds byte limit">>,
+        erlfdb_nif:get_error(2101)
+    ),
     ?assertEqual(<<"UNKNOWN_ERROR">>, erlfdb_nif:get_error(9999)).

--- a/test/erlfdb_02_anon_fdbserver_test.erl
+++ b/test/erlfdb_02_anon_fdbserver_test.erl
@@ -14,11 +14,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 basic_init_test() ->
     {ok, ClusterFile} = erlfdb_util:init_test_cluster([]),
     ?assert(is_binary(ClusterFile)).
-
 
 basic_open_test() ->
     {ok, ClusterFile} = erlfdb_util:init_test_cluster([]),
@@ -27,13 +25,11 @@ basic_open_test() ->
         ?assert(true)
     end).
 
-
 get_db_test() ->
     Db = erlfdb_util:get_test_db(),
     erlfdb:transactional(Db, fun(Tx) ->
         ?assert(true)
     end).
-
 
 get_set_get_test() ->
     Db = erlfdb_util:get_test_db(),
@@ -48,7 +44,6 @@ get_set_get_test() ->
     erlfdb:transactional(Db, fun(Tx) ->
         ?assertEqual(Val, erlfdb:wait(erlfdb:get(Tx, Key)))
     end).
-
 
 get_empty_test() ->
     Db1 = erlfdb_util:get_test_db(),

--- a/test/erlfdb_03_transaction_options_test.erl
+++ b/test/erlfdb_03_transaction_options_test.erl
@@ -14,50 +14,54 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 get_approximate_tx_size_test() ->
     Db1 = erlfdb_util:get_test_db(),
     erlfdb:transactional(Db1, fun(Tx) ->
-         ok = erlfdb:set(Tx, gen(10), gen(5000)),
-         TxSize1 = erlfdb:wait(erlfdb:get_approximate_size(Tx)),
-         ?assert(TxSize1 > 5000 andalso TxSize1 < 6000),
-         ok = erlfdb:set(Tx, gen(10), gen(5000)),
-         TxSize2 = erlfdb:wait(erlfdb:get_approximate_size(Tx)),
-         ?assert(TxSize2 > 10000)
+        ok = erlfdb:set(Tx, gen(10), gen(5000)),
+        TxSize1 = erlfdb:wait(erlfdb:get_approximate_size(Tx)),
+        ?assert(TxSize1 > 5000 andalso TxSize1 < 6000),
+        ok = erlfdb:set(Tx, gen(10), gen(5000)),
+        TxSize2 = erlfdb:wait(erlfdb:get_approximate_size(Tx)),
+        ?assert(TxSize2 > 10000)
     end).
-
 
 size_limit_test() ->
     Db1 = erlfdb_util:get_test_db(),
-    ?assertError({erlfdb_error, 2101}, erlfdb:transactional(Db1, fun(Tx) ->
-         erlfdb:set_option(Tx, size_limit, 10000),
-         erlfdb:set(Tx, gen(10), gen(11000))
-    end)).
-
+    ?assertError(
+        {erlfdb_error, 2101},
+        erlfdb:transactional(Db1, fun(Tx) ->
+            erlfdb:set_option(Tx, size_limit, 10000),
+            erlfdb:set(Tx, gen(10), gen(11000))
+        end)
+    ).
 
 writes_allowed_test() ->
     Db1 = erlfdb_util:get_test_db(),
-    ?assertError(writes_not_allowed, erlfdb:transactional(Db1, fun(Tx) ->
-        ?assert(erlfdb:get_writes_allowed(Tx)),
+    ?assertError(
+        writes_not_allowed,
+        erlfdb:transactional(Db1, fun(Tx) ->
+            ?assert(erlfdb:get_writes_allowed(Tx)),
 
-        erlfdb:set_option(Tx, disallow_writes),
-        ?assert(not erlfdb:get_writes_allowed(Tx)),
+            erlfdb:set_option(Tx, disallow_writes),
+            ?assert(not erlfdb:get_writes_allowed(Tx)),
 
-        erlfdb:set_option(Tx, allow_writes),
-        ?assert(erlfdb:get_writes_allowed(Tx)),
+            erlfdb:set_option(Tx, allow_writes),
+            ?assert(erlfdb:get_writes_allowed(Tx)),
 
-        erlfdb:set_option(Tx, disallow_writes),
-        erlfdb:set(Tx, gen(10), gen(10))
-    end)).
-
+            erlfdb:set_option(Tx, disallow_writes),
+            erlfdb:set(Tx, gen(10), gen(10))
+        end)
+    ).
 
 once_writes_happend_cannot_disallow_them_test() ->
     Db1 = erlfdb_util:get_test_db(),
-    ?assertError(badarg, erlfdb:transactional(Db1, fun(Tx) ->
-        ok = erlfdb:set(Tx, gen(10), gen(10)),
-        erlfdb:set_option(Tx, disallow_writes)
-    end)).
-
+    ?assertError(
+        badarg,
+        erlfdb:transactional(Db1, fun(Tx) ->
+            ok = erlfdb:set(Tx, gen(10), gen(10)),
+            erlfdb:set_option(Tx, disallow_writes)
+        end)
+    ).
 
 has_watches_test() ->
     Db1 = erlfdb_util:get_test_db(),
@@ -73,22 +77,25 @@ has_watches_test() ->
     ?assert(After),
     ?assert(not AfterReset).
 
-
 cannot_set_watches_if_writes_disallowed_test() ->
     Db1 = erlfdb_util:get_test_db(),
-    ?assertError(writes_not_allowed, erlfdb:transactional(Db1, fun(Tx) ->
-        erlfdb:set_option(Tx, disallow_writes),
-        erlfdb:watch(Tx, gen(10))
-    end)).
-
+    ?assertError(
+        writes_not_allowed,
+        erlfdb:transactional(Db1, fun(Tx) ->
+            erlfdb:set_option(Tx, disallow_writes),
+            erlfdb:watch(Tx, gen(10))
+        end)
+    ).
 
 size_limit_on_db_handle_test() ->
     Db1 = erlfdb_util:get_test_db(),
     erlfdb:set_option(Db1, size_limit, 10000),
-    ?assertError({erlfdb_error, 2101}, erlfdb:transactional(Db1, fun(Tx) ->
-         erlfdb:set(Tx, gen(10), gen(11000))
-    end)).
-
+    ?assertError(
+        {erlfdb_error, 2101},
+        erlfdb:transactional(Db1, fun(Tx) ->
+            erlfdb:set(Tx, gen(10), gen(11000))
+        end)
+    ).
 
 gen(Size) when is_integer(Size), Size > 1 ->
     RandBin = crypto:strong_rand_bytes(Size - 1),

--- a/test/erlfdb_04_snapshot_test.erl
+++ b/test/erlfdb_04_snapshot_test.erl
@@ -14,18 +14,16 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 snapshot_from_tx_test() ->
     Db = erlfdb_util:get_test_db(),
     Key = gen(10),
     Val = gen(10),
     erlfdb:set(Db, Key, Val),
     erlfdb:transactional(Db, fun(Tx) ->
-         ?assertEqual(Val, erlfdb:wait(erlfdb:get_ss(Tx, Key))),
-         Ss = erlfdb:snapshot(Tx),
-         ?assertEqual(Val, erlfdb:wait(erlfdb:get(Ss, Key)))
+        ?assertEqual(Val, erlfdb:wait(erlfdb:get_ss(Tx, Key))),
+        Ss = erlfdb:snapshot(Tx),
+        ?assertEqual(Val, erlfdb:wait(erlfdb:get(Ss, Key)))
     end).
-
 
 snapshot_from_a_snapshot_test() ->
     Db = erlfdb_util:get_test_db(),
@@ -33,11 +31,10 @@ snapshot_from_a_snapshot_test() ->
     Val = gen(10),
     erlfdb:set(Db, Key, Val),
     erlfdb:transactional(Db, fun(Tx) ->
-         Ss = erlfdb:snapshot(Tx),
-         ?assertEqual(Val, erlfdb:wait(erlfdb:get_ss(Ss, Key))),
-         Ss = erlfdb:snapshot(Ss)
+        Ss = erlfdb:snapshot(Tx),
+        ?assertEqual(Val, erlfdb:wait(erlfdb:get_ss(Ss, Key))),
+        Ss = erlfdb:snapshot(Ss)
     end).
-
 
 gen(Size) when is_integer(Size), Size > 1 ->
     RandBin = crypto:strong_rand_bytes(Size - 1),

--- a/test/erlfdb_05_get_next_tx_id_test.erl
+++ b/test/erlfdb_05_get_next_tx_id_test.erl
@@ -14,12 +14,14 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 get_tx_id_test() ->
     Db = erlfdb_util:get_test_db(),
     erlfdb:transactional(Db, fun(Tx) ->
-        lists:foreach(fun(I) ->
-            ?assertEqual(I, erlfdb:get_next_tx_id(Tx))
-        end, lists:seq(0, 65535)),
+        lists:foreach(
+            fun(I) ->
+                ?assertEqual(I, erlfdb:get_next_tx_id(Tx))
+            end,
+            lists:seq(0, 65535)
+        ),
         ?assertError(badarg, erlfdb:get_next_tx_id(Tx))
     end).


### PR DESCRIPTION
This PR adds `erlfmt` as a plugin so you can execute `rebar3 fmt` and then applies the results of `rebar3 fmt -w`. I put an `%% erlfmt-ignore` over a couple of functions where I felt that the hand-crafted style was much better (e.g. places where we had dozens of function clauses, and the extra line between each clause significantly improved readability).

I checked that `erlfmt` did not change the actual compiled output by manually running the following command for every source file. After temporarily adjusting `?NOT_LOADED` in `erlfdb_nif` to omit the `?LINE` info I got agreement across the board in src/:

> compile:file("old_src/erlfdb.erl", [deterministic, binary, no_line_info]) =:= compile:file("src/erlfdb.erl", [deterministic, binary, no_line_info]).