### PR TITLE
Automate execution of binding tests, support API 630

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,12 +20,15 @@ RUN set -ex; \
 
 # FDB bindings tester uses the Python bindings; install them from a
 # package to avoid building FDB from source
-# TODO FDB 6.3+ uses python3, we'll need to update it here
 RUN set -ex; \
     wget https://www.foundationdb.org/downloads/${FDB_VERSION}/bindings/python/foundationdb-${FDB_VERSION}.tar.gz; \
     tar zxf foundationdb-${FDB_VERSION}.tar.gz; \
     cd foundationdb-${FDB_VERSION}; \
-    python setup.py install; \
+    if [ "${FDB_VERSION}" < "6.3.0" ]; then \
+        python setup.py install; \
+    else \
+        python3 setup.py install; \
+    fi; \
     rm ../foundationdb-${FDB_VERSION}.tar.gz
 
 # Clone FoundationDB repo to retrieve bindings tester package and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,47 @@ jobs:
         if: ${{ failure() }}
         with:
           limit-access-to-actor: true
+
+  binding_tester:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-name: [api, directory, directory_hca, tuple]
+        api-version: [610, 620, 630]
+        include:
+          # The `scripted` test only supports the latest API version
+          - test-name: scripted
+            api-version: 630
+    container:
+      image: apache/couchdbci-debian:erlfdb-erlang-24.1.5.0-fdb-6.3.18-1
+    services:
+      foundationdb:
+        image: foundationdb/foundationdb:6.3.18
+    steps:
+      - name: Create FDB cluster file
+        env:
+          # This needs to match the name of the service above so the script can do
+          # a DNS lookup to write down the coordinator IP in the fdb.cluster file
+          FDB_COORDINATOR: foundationdb
+        shell: bash
+        run: /usr/local/bin/create_cluster_file.bash
+      - name: Initialize FDB database
+        run: fdbcli --exec "configure new single ssd"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Compile erlfdb
+        run: rebar3 compile
+      - name: Execute binding test
+        env:
+          TEST_NAME: ${{ matrix.test-name }}
+          API_VERSION: ${{ matrix.api-version }}
+          ERL_LIBS: _build/default/lib/erlfdb/
+        run: |
+          mkdir -p /usr/src/erlfdb/test/
+          ln -s $GITHUB_WORKSPACE/test/tester.es /usr/src/erlfdb/test/tester.es
+          /usr/src/foundationdb/bindings/bindingtester/bindingtester.py erlang \
+              --test-name $TEST_NAME \
+              --api-version $API_VERSION \
+              --num-ops 10000

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -110,8 +110,9 @@
     has_watches/1,
     get_writes_allowed/1,
 
-    % Locality
+    % Locality and Statistics
     get_addresses_for_key/2,
+    get_estimated_range_size/3,
 
     % Get conflict information
     get_conflicting_keys/1,
@@ -544,6 +545,11 @@ get_addresses_for_key(?IS_TX = Tx, Key) ->
     erlfdb_nif:transaction_get_addresses_for_key(Tx, Key);
 get_addresses_for_key(?IS_SS = SS, Key) ->
     get_addresses_for_key(?GET_TX(SS), Key).
+
+get_estimated_range_size(?IS_TX = Tx, StartKey, EndKey) ->
+    erlfdb_nif:transaction_get_estimated_range_size(Tx, StartKey, EndKey);
+get_estimated_range_size(?IS_SS = SS, StartKey, EndKey) ->
+    erlfdb_nif:transaction_get_estimated_range_size(?GET_TX(SS), StartKey, EndKey).
 
 get_conflicting_keys(?IS_TX = Tx) ->
     StartKey = <<16#FF, 16#FF, "/transaction/conflicting_keys/">>,

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -36,6 +36,7 @@
     transaction_set_read_version/2,
     transaction_get_read_version/1,
     transaction_get/3,
+    transaction_get_estimated_range_size/3,
     transaction_get_key/3,
     transaction_get_addresses_for_key/2,
     transaction_get_range/9,
@@ -265,6 +266,14 @@ transaction_get_read_version({erlfdb_transaction, Tx}) ->
     future().
 transaction_get({erlfdb_transaction, Tx}, Key, Snapshot) ->
     erlfdb_transaction_get(Tx, Key, Snapshot).
+
+-spec transaction_get_estimated_range_size(
+    transaction(),
+    StartKey :: binary(),
+    EndKey :: binary()
+) -> future().
+transaction_get_estimated_range_size({erlfdb_transaction, Tx}, StartKey, EndKey) ->
+    erlfdb_transaction_get_estimated_range_size(Tx, StartKey, EndKey).
 
 -spec transaction_get_key(
     transaction(),
@@ -511,6 +520,7 @@ erlfdb_transaction_set_option(_Transaction, _TransactionOption, _Value) -> ?NOT_
 erlfdb_transaction_set_read_version(_Transaction, _Version) -> ?NOT_LOADED.
 erlfdb_transaction_get_read_version(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get(_Transaction, _Key, _Snapshot) -> ?NOT_LOADED.
+erlfdb_transaction_get_estimated_range_size(_Transaction, _SKey, _EKey) -> ?NOT_LOADED.
 erlfdb_transaction_get_key(_Transaction, _KeySelector, _Snapshot) -> ?NOT_LOADED.
 erlfdb_transaction_get_addresses_for_key(_Transaction, _Key) -> ?NOT_LOADED.
 erlfdb_transaction_get_range(

--- a/test/tester.es
+++ b/test/tester.es
@@ -485,6 +485,22 @@ execute(TxObj, St, <<"GET">>) ->
     end,
     St;
 
+execute(TxObj, St, <<"GET_ESTIMATED_RANGE_SIZE">>) ->
+    [StartKey, EndKey] = stack_pop(St, 2),
+    Value = case erlfdb:get_estimated_range_size(TxObj, StartKey, EndKey) of
+        {erlfdb_future, _, _} = Future ->
+            erlfdb:wait(Future);
+        Else ->
+            Else
+    end,
+    case Value of
+        Size when is_integer(Size) ->
+            stack_push(St, <<"GOT_ESTIMATED_RANGE_SIZE">>);
+        BadResult ->
+            stack_push(St, BadResult)
+    end,
+    St;
+
 execute(TxObj, St, <<"GET_KEY">>) ->
     [Key, OrEqual, Offset, Prefix] = stack_pop(St, 4),
     Selector = {Key, OrEqual, Offset},


### PR DESCRIPTION
This PR adds a GHA job that uses the same container image as the .devcontainer. It runs 10000 operations for each of the binding tests for every supported API version (currently 610 / 620 / 630). It relies on a service container for the underlying FDB server.

It also implements the new `get_estimated_range_size` interface required to declare support for the 630 API.

Closes #31
Closes #38