### PR TITLE
Configure FDB_API_VERSION dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
 
   build_on_linux:
+    strategy:
+      matrix:
+        fdb-version: ['6.2.30', '6.3.22']
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -17,7 +20,7 @@ jobs:
           submodules: recursive
       - name: Install FoundationDB
         env:
-          FDB_VERSION: '6.2.30'
+          FDB_VERSION: ${{ matrix.fdb-version }}
         run: |
           wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb
           wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-server_${FDB_VERSION}-1_amd64.deb
@@ -41,6 +44,10 @@ jobs:
           limit-access-to-actor: true
 
   build_on_windows:
+    strategy:
+      matrix:
+        # Windows builds are not being published beyond 6.3.9 right now
+        fdb-version: ['6.2.30', '6.3.9']
     runs-on: windows-latest
     env:
       # Set to 1 for verbose rebar3 logging
@@ -55,7 +62,7 @@ jobs:
           submodules: recursive
       - name: Install FoundationDB
         env:
-          FDB_VERSION: '6.2.30'
+          FDB_VERSION: ${{ matrix.fdb-version }}
         # Download FDB .msi, install it, and add FDB to the $env:Path for all future steps
         run: |
           Set-PSDebug -Trace 1

--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -64,6 +64,7 @@ ATOM_MAP(external_client_directory);
 ATOM_MAP(disable_local_client);
 ATOM_MAP(disable_client_statistics_logging);
 ATOM_MAP(enable_slow_task_profiling);
+ATOM_MAP(enable_run_loop_profiling);
 
 
 // Database Options

--- a/c_src/fdb.h
+++ b/c_src/fdb.h
@@ -13,7 +13,10 @@
 #ifndef ERLFDB_FDB_H
 #define ERLFDB_FDB_H
 
+#ifndef FDB_API_VERSION
 #define FDB_API_VERSION 620
+#endif // Allow command-line override of default FDB_API_VERSION
+
 #include <foundationdb/fdb_c.h>
 
 #endif // Included fdb.h

--- a/c_src/main.c
+++ b/c_src/main.c
@@ -504,7 +504,13 @@ erlfdb_network_set_option(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         option = FDB_NET_OPTION_DISABLE_CLIENT_STATISTICS_LOGGING;
     } else if(IS_ATOM(argv[0], enable_slow_task_profiling)) {
         option = FDB_NET_OPTION_ENABLE_SLOW_TASK_PROFILING;
-    } else {
+    }
+    #if FDB_API_VERSION >= 630
+    else if(IS_ATOM(argv[0], enable_run_loop_profiling)) {
+        option = FDB_NET_OPTION_ENABLE_RUN_LOOP_PROFILING;
+    }
+    #endif
+    else {
         return enif_make_badarg(env);
     }
 

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
     {"priv/erlfdb_nif.so", ["c_src/*.c"]}
 ]}.
 
-% port_env compile / link flags dynamically generated in rebar.config.script
+% port_env compiler / linker flags dynamically generated in rebar.config.script
 
 {profiles, [
     {devcontainer, [

--- a/rebar.config
+++ b/rebar.config
@@ -17,29 +17,7 @@
     {"priv/erlfdb_nif.so", ["c_src/*.c"]}
 ]}.
 
-{port_env, [
-    {
-        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CFLAGS",
-        "$CFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"
-    },
-    {
-        "win32",
-        "CFLAGS",
-        "$CFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"
-    },
-
-    {
-        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "LDFLAGS",
-        "$LDFLAGS -L/usr/local/lib -lfdb_c"
-    },
-    {
-        "win32",
-        "LDFLAGS",
-        "$LDFLAGS /LIBPATH:\"c:/Program Files/foundationdb/lib/foundationdb\" fdb_c.lib"
-    }
-]}.
+% port_env compile / link flags dynamically generated in rebar.config.script
 
 {profiles, [
     {devcontainer, [

--- a/rebar.config
+++ b/rebar.config
@@ -24,19 +24,9 @@
         "$CFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"
     },
     {
-        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CXXFLAGS",
-        "$CXXFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror"
-    },
-    {
         "win32",
         "CFLAGS",
         "$CFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"
-    },
-    {
-        "win32",
-        "CXXFLAGS",
-        "$CXXFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG"
     },
 
     {

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,34 @@
+% Hacky means to extract API version from fdbcli protocol version output
+% See https://github.com/apple/foundationdb/blob/master/flow/ProtocolVersion.h
+MaxAPIVersion =
+    begin
+        VsnInfo = os:cmd("fdbcli --version"),
+        {match, [ProtocolStr]} = re:run(VsnInfo, "protocol ([a-f0-9]*)", [{capture, [1], list}]),
+        ProtocolVsn = list_to_integer(ProtocolStr, 16),
+        APIVersionBytes = (ProtocolVsn band 16#0000000FFF00000) bsr 20,
+        integer_to_list(APIVersionBytes, 16)
+    end.
+
+[{port_env, [
+    {
+        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
+        "CFLAGS",
+        "$CFLAGS -I/usr/local/include -Ic_src/ -g -Wall -Werror -DFDB_API_VERSION=" ++ MaxAPIVersion
+    },
+    {
+        "win32",
+        "CFLAGS",
+        "$CFLAGS /I\"c:/Program Files/foundationdb/include\" /O2 /DNDEBUG /DFDB_API_VERSION=" ++ MaxAPIVersion
+    },
+
+    {
+        "(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
+        "LDFLAGS",
+        "$LDFLAGS -L/usr/local/lib -lfdb_c"
+    },
+    {
+        "win32",
+        "LDFLAGS",
+        "$LDFLAGS /LIBPATH:\"c:/Program Files/foundationdb/lib/foundationdb\" fdb_c.lib"
+    }
+]}] ++ CONFIG.

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -110,7 +110,9 @@
     | external_client_directory
     | disable_local_client
     | disable_client_statistics_logging
-    | enable_slow_task_profiling.
+    | enable_slow_task_profiling
+    % API version 630+
+    | enable_run_loop_profiling.
 
 -type database_option() ::
     location_cache_size


### PR DESCRIPTION
This patch set dynamically detects the maximum API version supported by the installed FDB client library and builds the NIF wrapper against that version automatically.

Older API versions can still be selected at runtime as usual through the application environment; this just ensures we have the largest possible range at our disposal, without restricting the versions of the client library we can support with a single branch of this codebase.

Closes #34 
Closes #38