### PR TITLE
Fix OOB array access in get_string_array

### DIFF
--- a/c_src/main.c
+++ b/c_src/main.c
@@ -265,7 +265,7 @@ erlfdb_future_get_string_array(ErlNifEnv* env, ErlFDBFuture* f)
 
     ret = enif_make_list(env, 0);
 
-    for(i = count; i > 0; i--) {
+    for(i = count - 1; i >= 0; i--) {
         buf = enif_make_new_binary(env, strlen(strings[i]), &bin);
         memcpy(buf, strings[i], strlen(strings[i]));
         ret = enif_make_list_cell(env, bin, ret);

--- a/test/erlfdb_06_get_addresses_test.erl
+++ b/test/erlfdb_06_get_addresses_test.erl
@@ -1,0 +1,21 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(erlfdb_06_get_addresses_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+get_addresses_for_key_test() ->
+    Db = erlfdb_util:get_test_db(),
+    % Does not matter whether foo exists in Db
+    Result = erlfdb:get_addresses_for_key(Db, <<"foo">>),
+    ?assertMatch([X | _] when is_binary(X), Result).


### PR DESCRIPTION
Silly bug here, but we didn't catch because for some reason the get_addresses_for_key function is not part of the bindings tester specifications. I added a brutally simple unit test to cover it.