### PR TITLE
Fix issues caused by foundationdb.org breakage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,23 +13,11 @@ ARG FDB_VERSION
 
 # Install the FDB client used underneath erlfdb
 RUN set -ex; \
-    wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
+    wget https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
     mkdir /var/lib/foundationdb; \
     dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
     rm foundationdb-clients_${FDB_VERSION}-1_amd64.deb
 
-# FDB bindings tester uses the Python bindings; install them from a
-# package to avoid building FDB from source
-RUN set -ex; \
-    wget https://www.foundationdb.org/downloads/${FDB_VERSION}/bindings/python/foundationdb-${FDB_VERSION}.tar.gz; \
-    tar zxf foundationdb-${FDB_VERSION}.tar.gz; \
-    cd foundationdb-${FDB_VERSION}; \
-    if [ "${FDB_VERSION}" < "6.3.0" ]; then \
-        python setup.py install; \
-    else \
-        python3 setup.py install; \
-    fi; \
-    rm ../foundationdb-${FDB_VERSION}.tar.gz
 
 # Clone FoundationDB repo to retrieve bindings tester package and
 # patch it to support erlfdb
@@ -43,9 +31,14 @@ RUN set -ex; \
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        dnsutils; \
+        dnsutils \
+        python3-setuptools \
+        python3-pip; \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=fdb /var/fdb/scripts/create_cluster_file.bash /usr/local/bin/
+# FDB bindings tester uses the Python bindings
+RUN pip3 install foundationdb==${FDB_VERSION}
+
+COPY create_cluster_file.bash /usr/local/bin/
 
 CMD sleep infinity

--- a/.devcontainer/create_cluster_file.bash
+++ b/.devcontainer/create_cluster_file.bash
@@ -1,0 +1,52 @@
+#! /bin/bash
+
+#
+# create_cluster_file.bash
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script creates a cluster file for a server or client.
+# This takes the cluster file path from the FDB_CLUSTER_FILE
+# environment variable, with a default of /etc/foundationdb/fdb.cluster
+#
+# The name of the coordinator must be defined in the FDB_COORDINATOR environment
+# variable, and it must be a name that can be resolved through DNS.
+
+function create_cluster_file() {
+	FDB_CLUSTER_FILE=${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}
+	mkdir -p $(dirname $FDB_CLUSTER_FILE)
+
+	if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
+		echo "$FDB_CLUSTER_FILE_CONTENTS" > $FDB_CLUSTER_FILE
+	elif [[ -n $FDB_COORDINATOR ]]; then
+		coordinator_ip=$(dig +short $FDB_COORDINATOR)
+		if [[ -z "$coordinator_ip" ]]; then
+			echo "Failed to look up coordinator address for $FDB_COORDINATOR" 1>&2
+			exit 1
+		fi
+		coordinator_port=${FDB_COORDINATOR_PORT:-4500}
+		echo "docker:docker@$coordinator_ip:$coordinator_port" > $FDB_CLUSTER_FILE
+	else
+		echo "FDB_COORDINATOR environment variable not defined" 1>&2
+		exit 1
+	fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	create_cluster_file "$@"
+fi

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
         ERLANG_VERSION: "24"
 
         # This should always match the value in fdb.image
-        FDB_VERSION: "6.2.30"
+        FDB_VERSION: "6.3.23"
 
     environment:
       # This needs to match the name of the FoundationDB service below
@@ -28,4 +28,4 @@ services:
     network_mode: service:fdb
 
   fdb:
-    image: foundationdb/foundationdb:6.2.30
+    image: foundationdb/foundationdb:6.3.23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,8 @@ jobs:
         run: |
           Set-PSDebug -Trace 1
           Invoke-WebRequest -Uri https://github.com/apple/foundationdb/releases/download/$env:FDB_VERSION/foundationdb-$env:FDB_VERSION-x64.msi -OutFile foundationdb-$env:FDB_VERSION-x64.msi
-          msiexec /i foundationdb-$env:FDB_VERSION-x64.msi /passive
-          echo "c:/Program Files/foundationdb/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Start-Process -Wait -FilePath msiexec -ArgumentList /i, foundationdb-$env:FDB_VERSION-x64.msi, /passive
+          echo "C:\Program Files\foundationdb\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install FoundationDB (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
         run: |


### PR DESCRIPTION
The foundationdb.org collapse and subsequent move to GitHub created a bit of fallout:

* Update package URLs from foundationdb.org to github.com

* Install Python package via pip as it's not published on GitHub

* Bump version to 6.3.23 as pypi has [limited release selection](https://pypi.org/project/foundationdb/#history)

* Vendor the create_cluster_file.bash script (FDB elected to remove it from their published container builds).