### PR TITLE
Fix C prototype declaration to match implementation

### DIFF
--- a/c_src/atoms.h
+++ b/c_src/atoms.h
@@ -22,7 +22,7 @@
 #undef ATOM_MAP
 
 
-void erlfdb_init_atoms();
+void erlfdb_init_atoms(ErlNifEnv* env);
 
 
 #endif // Included atoms.h


### PR DESCRIPTION
This PR resolves a compile error on my system when building erlfdb. The error is:

```
===> In file included from /Users/jstimpson/dev/erlang/JesseStimpson.couchdb-erlfdb/c_src/atoms.c:13:
c_src/atoms.h:25:6: error: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
void erlfdb_init_atoms();
     ^
                       void
/Users/jstimpson/dev/erlang/JesseStimpson.couchdb-erlfdb/c_src/atoms.c:23:1: error: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
erlfdb_init_atoms(ErlNifEnv* env)
^
2 errors generated.
```

I have the following local version of clang, and haven't specified any env flags. 
```
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Thanks for taking a look!