### PR TITLE
Adds FDB Tenants

### DIFF
--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -29,6 +29,7 @@ ATOM_MAP(not_found);
 ATOM_MAP(erlfdb_error);
 ATOM_MAP(erlfdb_future);
 ATOM_MAP(erlfdb_database);
+ATOM_MAP(erlfdb_tenant);
 ATOM_MAP(erlfdb_transaction);
 
 ATOM_MAP(invalid_future_type);
@@ -109,6 +110,7 @@ ATOM_MAP(disallow_writes);
 ATOM_MAP(include_port_in_address);
 ATOM_MAP(use_provisional_proxies);
 ATOM_MAP(report_conflicting_keys);
+ATOM_MAP(special_key_space_enable_writes);
 
 
 // Streaming mode

--- a/c_src/fdb.h
+++ b/c_src/fdb.h
@@ -13,8 +13,11 @@
 #ifndef ERLFDB_FDB_H
 #define ERLFDB_FDB_H
 
+// FDB_LATEST_API_VERSION
+#include <foundationdb/fdb_c_apiversion.g.h>
+
 #ifndef FDB_API_VERSION
-#define FDB_API_VERSION 620
+#define FDB_API_VERSION FDB_LATEST_API_VERSION
 #endif // Allow command-line override of default FDB_API_VERSION
 
 #include <foundationdb/fdb_c.h>

--- a/c_src/resources.c
+++ b/c_src/resources.c
@@ -15,6 +15,7 @@
 
 ErlNifResourceType* ErlFDBFutureRes;
 ErlNifResourceType* ErlFDBDatabaseRes;
+ErlNifResourceType* ErlFDBTenantRes;
 ErlNifResourceType* ErlFDBTransactionRes;
 
 
@@ -43,6 +44,18 @@ erlfdb_init_resources(ErlNifEnv* env)
             NULL
         );
     if(ErlFDBDatabaseRes == NULL) {
+        return 0;
+    }
+
+    ErlFDBTenantRes = enif_open_resource_type(
+            env,
+            NULL,
+            "erlfdb_tenant",
+            erlfdb_tenant_dtor,
+            ERL_NIF_RT_CREATE,
+            NULL
+        );
+    if(ErlFDBTenantRes == NULL) {
         return 0;
     }
 
@@ -88,6 +101,17 @@ erlfdb_database_dtor(ErlNifEnv* env, void* obj)
 
     if(d->database != NULL) {
         fdb_database_destroy(d->database);
+    }
+}
+
+
+void
+erlfdb_tenant_dtor(ErlNifEnv* env, void* obj)
+{
+    ErlFDBTenant* ten = (ErlFDBTenant*) obj;
+
+    if(ten->tenant != NULL) {
+        fdb_tenant_destroy(ten->tenant);
     }
 }
 

--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -21,6 +21,7 @@
 
 extern ErlNifResourceType* ErlFDBFutureRes;
 extern ErlNifResourceType* ErlFDBDatabaseRes;
+extern ErlNifResourceType* ErlFDBTenantRes;
 extern ErlNifResourceType* ErlFDBTransactionRes;
 
 
@@ -54,6 +55,10 @@ typedef struct _ErlFDBDatabase
     FDBDatabase* database;
 } ErlFDBDatabase;
 
+typedef struct _ErlFDBTenant
+{
+    FDBTenant* tenant;
+} ErlFDBTenant;
 
 typedef struct _ErlFDBTransaction
 {
@@ -69,6 +74,7 @@ typedef struct _ErlFDBTransaction
 int erlfdb_init_resources(ErlNifEnv* env);
 void erlfdb_future_dtor(ErlNifEnv* env, void* obj);
 void erlfdb_database_dtor(ErlNifEnv* env, void* obj);
+void erlfdb_tenant_dtor(ErlNifEnv* env, void* obj);
 void erlfdb_transaction_dtor(ErlNifEnv* env, void* obj);
 
 

--- a/src/erlfdb.app.src
+++ b/src/erlfdb.app.src
@@ -18,7 +18,7 @@
     {maintainers, ["Paul J. Davis"]},
     {links, [{"GitHub", "https://github.com/cloudant-labs/couchdb-erlfdb"}]},
     {env, [
-        {api_version, 620},
+        {api_version, 730},
         {network_options, []}
     ]}
 ]}.

--- a/src/erlfdb_tenant_management.erl
+++ b/src/erlfdb_tenant_management.erl
@@ -1,0 +1,54 @@
+-module(erlfdb_tenant_management).
+
+-export([transactional/2, list_tenants/1, list_tenants/4, get_tenant/2, create_tenant/2, delete_tenant/2]).
+
+-define(TENANT_MAP(TenantName), iolist_to_binary([<<16#FF, 16#FF, "/management/tenant/map/">>, TenantName])).
+
+-define(IS_DB, {erlfdb_database, _}).
+-define(IS_TX, {erlfdb_transaction, _}).
+
+transactional(?IS_DB = Db, UserFun) ->
+    erlfdb:transactional(Db, fun(Tx) ->
+        ok = erlfdb:set_option(Tx, special_key_space_enable_writes),
+        UserFun(Tx)
+    end).
+
+list_tenants(DbOrTx) ->
+    % Tenant names cannot start with \xff, so this is guaranteed to get all tenants
+    list_tenants(DbOrTx, <<>>, <<16#FF>>, []).
+
+list_tenants(?IS_DB = Db, Begin, End, Opts) ->
+    erlfdb:transactional(Db, fun(Tx) ->
+        ok = erlfdb:set_option(Tx, read_system_keys),
+        erlfdb:wait(list_tenants(Tx, Begin, End, Opts))
+    end);
+list_tenants(?IS_TX = Tx, Begin, End, Opts) ->
+    erlfdb:get_range(Tx, ?TENANT_MAP(Begin), ?TENANT_MAP(End), Opts).
+
+get_tenant(?IS_DB = Db, TenantName) ->
+    erlfdb:transactional(Db, fun(Tx) ->
+        ok = erlfdb:set_option(Tx, read_system_keys),
+        erlfdb:wait(get_tenant(Tx, TenantName))
+    end);
+get_tenant(?IS_TX = Tx, TenantName) ->
+    erlfdb:get(Tx, ?TENANT_MAP(TenantName)).
+
+create_tenant(?IS_DB = Db, TenantName) ->
+    transactional(Db, fun(Tx) ->
+        case erlfdb:wait(get_tenant(Tx, TenantName)) of
+            not_found ->
+                erlfdb:wait(create_tenant(Tx, TenantName));
+            _ ->
+                % tenant_already_exists
+                erlang:error({erlfdb_error, 2132})
+        end
+    end);
+create_tenant(?IS_TX = Tx, TenantName) ->
+    erlfdb:set(Tx, ?TENANT_MAP(TenantName), <<>>).
+
+delete_tenant(?IS_DB = Db, TenantName) ->
+    transactional(Db, fun(Tx) ->
+        erlfdb:wait(delete_tenant(Tx, TenantName))
+    end);
+delete_tenant(?IS_TX = Tx, TenantName) ->
+    erlfdb:clear(Tx, ?TENANT_MAP(TenantName)).

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -66,7 +66,12 @@ create_and_open_test_tenant(Db, Options) ->
 create_and_open_tenant(Db, Options, TenantName) ->
     case proplists:get_value(empty, Options) of
         true ->
-            clear_and_delete_tenant(Db, TenantName);
+            case erlfdb_tenant_management:get_tenant(Db, TenantName) of
+                not_found ->
+                    ok;
+                _ ->
+                    clear_tenant(Db, TenantName)
+            end;
         _ ->
             ok
     end,

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -66,7 +66,7 @@ create_and_open_test_tenant(Db, Options) ->
 create_and_open_tenant(Db, Options, TenantName) ->
     case proplists:get_value(empty, Options) of
         true ->
-            clear_tenant(Db, TenantName);
+            clear_and_delete_tenant(Db, TenantName);
         _ ->
             ok
     end,

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -260,7 +260,7 @@ init_fdb_db(ClusterFile, Options) ->
             DefaultFDBCli -> "fdbcli";
             FDBCli0 -> FDBCli0
         end,
-    Fmt = "~s -C ~s --exec \"configure new single ssd\"",
+    Fmt = "~s -C ~s --exec \"configure new single ssd tenant_mode=optional_experimental\"",
     Cmd = lists:flatten(io_lib:format(Fmt, [FDBCli, ClusterFile])),
     case os:cmd(Cmd) of
         "Database created" ++ _ -> ok;

--- a/src/erlfdb_util.erl
+++ b/src/erlfdb_util.erl
@@ -30,6 +30,9 @@
     debug_cluster/3
 ]).
 
+% Some systems are unable to compute the shared machine id without root,
+% so we'll provide a hardcoded machine id for our managed fdbserver
+-define(TEST_CLUSTER_MACHINE_ID, <<?MODULE_STRING>>).
 -define(TEST_TENANT_NAME, <<?MODULE_STRING, ".test">>).
 
 get_test_db() ->
@@ -167,7 +170,9 @@ init_test_cluster_int(Options) ->
             <<"-d">>,
             Dir,
             <<"-L">>,
-            Dir
+            Dir,
+            <<"-i">>,
+            ?TEST_CLUSTER_MACHINE_ID
         ],
         FDBPortOpts = [{args, FDBPortArgs}],
         FDBServer = erlang:open_port(FDBPortName, FDBPortOpts),


### PR DESCRIPTION
Hi!

This commit adds support for FDB Tenants to erlfdb, and I wanted to offer it for your consideration.

I used the source for the official FDB Python and Java clients as reference.

### Further guidance needed
There are some decisions that will probably raise an eyebrow. They are:

- Updated FDB_API_VERSION and api_version to 730, from 620. 
- Changed unit test `get_empty_test` to use Tenants. 

#### API version
Tenant support exists in some version after 620, though I did not pinpoint it precisely. Presumably this would be a breaking change for anyone using a cluster with <= 620. Guidance is appreciated here.

#### Empty Unit Test
I almost got myself into a pickle by running unit tests using a real cluster file. Perhaps I should have known better, but I didn't expect the unit tests to run a full `clear_range`. (Especially given that the unit tests are set to run with a simple `make` command). Luckily, the cluster I used only contained dev data, so no harm done. However, this seemed like an opportunity to use tenants to conduct the test in a safe manner.